### PR TITLE
Fix doc-comments to use 16-bytes keys instead of 10-byte keys

### DIFF
--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -30,9 +30,9 @@ impl Drop for Hkdf {
 /// use orion::hkdf::Hkdf;
 /// use orion::util::gen_rand_key;
 ///
-/// let key = gen_rand_key(10);
-/// let salt = gen_rand_key(10);
-/// let info = gen_rand_key(10);
+/// let key = gen_rand_key(16);
+/// let salt = gen_rand_key(16);
+/// let info = gen_rand_key(16);
 ///
 /// let dk = Hkdf { salt: salt, data: key, info: info, hmac: 256, length: 50 };
 /// dk.hkdf_compute();

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -31,8 +31,8 @@ impl Drop for Hmac {
 /// use orion::hmac::Hmac;
 /// use orion::util::gen_rand_key;
 ///
-/// let key = gen_rand_key(10);
-/// let message = gen_rand_key(10);
+/// let key = gen_rand_key(16);
+/// let message = gen_rand_key(16);
 ///
 /// let hmac_sha256 = Hmac { secret_key: key, message: message, sha2: 256 };
 ///


### PR DESCRIPTION
(the old comments might have mislead people into thinking 10-byte keys are safe)