### PR TITLE
Fix PBKDF2 length check

### DIFF
--- a/src/hazardous/pbkdf2.rs
+++ b/src/hazardous/pbkdf2.rs
@@ -112,33 +112,21 @@ pub fn derive_key(
     if iterations < 1 {
         return Err(UnknownCryptoError);
     }
-    if dk_out.len() > 274_877_906_880 {
-        return Err(UnknownCryptoError);
-    }
     if dk_out.is_empty() {
         return Err(UnknownCryptoError);
     }
 
     let mut hmac = hmac::init(password);
-    let dk_len = dk_out.len();
 
     for (idx, dk_block) in dk_out.chunks_mut(HLEN).enumerate() {
         let block_len = dk_block.len();
-        assert!(block_len <= dk_len);
-
         let block_idx = (1_u32).checked_add(idx as u32);
 
         if block_idx.is_some() {
             function_f(salt, iterations, block_idx.unwrap(), dk_block, block_len, &mut hmac);
+            hmac.reset();
         } else {
             return Err(UnknownCryptoError);
-        }
-
-        // Check if it's the last iteration, if yes don't process anything
-        if block_len < HLEN || (block_len * (idx + 1) == dk_len) {
-            break;
-        } else {
-            hmac.reset();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 
 #![cfg_attr(not(feature = "safe_api"), no_std)]
 #![forbid(unsafe_code)]
+#![deny(overflowing_literals)]
 
 extern crate byteorder;
 #[cfg(feature = "safe_api")]


### PR DESCRIPTION
Fixes #30. The fix has the same approach as the one used by [ring](https://github.com/briansmith/ring/blob/7e3682c02170f5eafa423b63bacfa018de2878a9/src/pbkdf2.rs#L161) and is also used in the `chacha20` module.