### PR TITLE
Use subtle v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand = { version = "0.6.1", optional = true }
 sha2 = { version = "0.8.0", default-features = false }
 tiny-keccak = "1.4.2"
 byteorder = { version = "1.2.7", default-features = false }
-subtle = { version = "1.0.0", default-features = false }
+subtle = { version = "2", default-features = false }
 clear_on_drop = "=0.2.3"
 
 [features]


### PR DESCRIPTION
As far as I can tell, the `ConstantTimeEq` trait is only used internally, and is not implemented on any public types, so this should be a semver-compatible change that does not require incrementing the major version.