### PR TITLE
Switch from rand to rand_os

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [dependencies]
-rand = { version = "0.6.1", optional = true }
+rand_os = { version = "0.1.1", optional = true }
 tiny-keccak = "1.4.2"
 byteorder = { version = "1.2.7", default-features = false }
 subtle = { version = "2", default-features = false }
@@ -27,7 +27,7 @@ clear_on_drop = "=0.2.3"
 
 [features]
 default = [ "safe_api" ]
-safe_api = [ "rand" ]
+safe_api = [ "rand_os" ]
 nightly = [ "clear_on_drop/nightly", "subtle/nightly", "safe_api" ]
 no_std = [ "clear_on_drop/nightly", "subtle/nightly" ]
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -24,7 +24,7 @@ extern crate core;
 
 use self::core::fmt;
 #[cfg(feature = "safe_api")]
-use rand;
+use rand_os::rand_core;
 
 /// Opaque error.
 #[derive(PartialEq)]
@@ -40,8 +40,8 @@ impl fmt::Debug for UnknownCryptoError {
 
 #[cfg(feature = "safe_api")]
 // Required for rand's generators
-impl From<rand::Error> for UnknownCryptoError {
-	fn from(_: rand::Error) -> Self { UnknownCryptoError }
+impl From<rand_core::Error> for UnknownCryptoError {
+	fn from(_: rand_core::Error) -> Self { UnknownCryptoError }
 }
 
 impl From<FinalizationCryptoError> for UnknownCryptoError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 extern crate byteorder;
 extern crate clear_on_drop;
 #[cfg(feature = "safe_api")]
-extern crate rand;
+extern crate rand_os;
 extern crate subtle;
 extern crate tiny_keccak;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -22,7 +22,9 @@
 
 use crate::errors;
 #[cfg(feature = "safe_api")]
-use rand::{rngs::OsRng, RngCore};
+use rand_os::rand_core::RngCore;
+#[cfg(feature = "safe_api")]
+use rand_os::OsRng;
 use subtle::ConstantTimeEq;
 
 #[must_use]


### PR DESCRIPTION
This avoids having unneeded dependencies that `rand` automatically imports. 