### PR TITLE
Remove inline attributes from public API's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,17 @@ matrix:
         - cargo fmt --all -- --check
         # Debug mode:
         # First sanitizers with default features
-        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --test mod --target x86_64-unknown-linux-gnu
+        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --tests --target x86_64-unknown-linux-gnu
         - RUSTFLAGS="-Z sanitizer=leak" cargo +nightly test --tests --target x86_64-unknown-linux-gnu
         # Then with nightly features
-        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --features nightly --test mod --target x86_64-unknown-linux-gnu
+        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --features nightly --tests --target x86_64-unknown-linux-gnu
         - RUSTFLAGS="-Z sanitizer=leak" cargo test --no-default-features --features nightly --tests --target x86_64-unknown-linux-gnu
         # Release:
         # First sanitizers with default features
-        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --test mod --release --target x86_64-unknown-linux-gnu
+        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --tests --release --target x86_64-unknown-linux-gnu
         - RUSTFLAGS="-Z sanitizer=leak" cargo +nightly test --tests --release --target x86_64-unknown-linux-gnu
         # Then with nightly features
-        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --features nightly --test mod --release --target x86_64-unknown-linux-gnu
+        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --features nightly --tests --release --target x86_64-unknown-linux-gnu
         - RUSTFLAGS="-Z sanitizer=leak" cargo test --no-default-features --features nightly --tests --release --target x86_64-unknown-linux-gnu
     # Ensure building in no_std is possible
     - env: TARGET=thumbv7em-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ exclude = [
 ]
 
 [dependencies]
-rand_os = { version = "0.1.1", optional = true }
+rand_os = { version = "0.1.2", optional = true }
 tiny-keccak = "1.4.2"
-byteorder = { version = "1.2.7", default-features = false }
+byteorder = { version = "1.3.1", default-features = false }
 subtle = { version = "2", default-features = false }
 clear_on_drop = "=0.2.3"
 
@@ -33,7 +33,7 @@ no_std = [ "clear_on_drop/nightly", "subtle/nightly" ]
 
 [dev-dependencies]
 hex = "0.3.2"
-serde_json = "1.0.33"
+serde_json = "1.0.37"
 
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orion"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["brycx <brycx@protonmail.com>"]
 description = "Easy and usable rust crypto"
 keywords = [ "cryptography", "blake2", "aead", "sha2", "xchacha20_poly1305" ]

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -109,6 +109,7 @@ use crate::{
 use byteorder::{ByteOrder, LittleEndian};
 
 #[must_use]
+#[inline]
 /// Poly1305 key generation using IETF ChaCha20.
 fn poly1305_key_gen(key: &[u8], nonce: &[u8]) -> Result<OneTimeKey, UnknownCryptoError> {
 	let one_time_key = OneTimeKey::from_slice(
@@ -123,6 +124,7 @@ fn poly1305_key_gen(key: &[u8], nonce: &[u8]) -> Result<OneTimeKey, UnknownCrypt
 }
 
 #[must_use]
+#[inline]
 /// Padding size that gives the needed bytes to pad `input` to an integral
 /// multiple of 16.
 fn padding(input: &[u8]) -> usize {
@@ -134,6 +136,7 @@ fn padding(input: &[u8]) -> usize {
 }
 
 #[must_use]
+#[inline]
 /// Process data to be authenticated using a `Poly1305` struct initialized with
 /// a one-time-key.
 fn process_authentication(

--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -202,7 +202,7 @@ impl core::fmt::Debug for Blake2b {
 }
 
 impl Blake2b {
-	#[inline]
+	#[inline(always)]
 	/// Increment the internal states offset value `t`.
 	fn increment_offset(&mut self, value: u64) {
 		self.t[0] += value;
@@ -211,7 +211,7 @@ impl Blake2b {
 		}
 	}
 
-	#[inline]
+	#[inline(always)]
 	#[allow(clippy::many_single_char_names)]
 	#[allow(clippy::too_many_arguments)]
 	/// The primitive mixing function G as defined in the RFC.
@@ -239,7 +239,7 @@ impl Blake2b {
 		w[b] = (w[b]).rotate_right(63u32);
 	}
 
-	#[inline]
+	#[inline(always)]
 	/// Perform a single round based on a message schedule selection.
 	fn round(&mut self, ri: usize, m: &mut [u64], w: &mut [u64]) {
 		self.prim_mix_g(m[SIGMA[ri][0]], m[SIGMA[ri][1]], 0, 4, 8, 12, w);

--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -202,7 +202,7 @@ impl core::fmt::Debug for Blake2b {
 }
 
 impl Blake2b {
-	#[inline(always)]
+	#[inline]
 	/// Increment the internal states offset value `t`.
 	fn increment_offset(&mut self, value: u64) {
 		self.t[0] += value;
@@ -211,7 +211,7 @@ impl Blake2b {
 		}
 	}
 
-	#[inline(always)]
+	#[inline]
 	#[allow(clippy::many_single_char_names)]
 	#[allow(clippy::too_many_arguments)]
 	/// The primitive mixing function G as defined in the RFC.
@@ -239,7 +239,7 @@ impl Blake2b {
 		w[b] = (w[b]).rotate_right(63u32);
 	}
 
-	#[inline(always)]
+	#[inline]
 	/// Perform a single round based on a message schedule selection.
 	fn round(&mut self, ri: usize, m: &mut [u64], w: &mut [u64]) {
 		self.prim_mix_g(m[SIGMA[ri][0]], m[SIGMA[ri][1]], 0, 4, 8, 12, w);
@@ -252,7 +252,6 @@ impl Blake2b {
 		self.prim_mix_g(m[SIGMA[ri][14]], m[SIGMA[ri][15]], 3, 4, 9, 14, w);
 	}
 
-	#[inline(always)]
 	#[allow(clippy::needless_range_loop)]
 	/// The compression function f as defined in the RFC.
 	fn compress_f(&mut self) {
@@ -302,7 +301,6 @@ impl Blake2b {
 	}
 
 	#[must_use]
-	#[inline(always)]
 	/// Reset to `init()` state.
 	pub fn reset(&mut self, secret_key: Option<&SecretKey>) -> Result<(), UnknownCryptoError> {
 		if secret_key.is_some() && (!self.is_keyed) {
@@ -329,7 +327,6 @@ impl Blake2b {
 	}
 
 	#[must_use]
-	#[inline(always)]
 	/// Update state with a `data`. This can be called multiple times.
 	pub fn update(&mut self, data: &[u8]) -> Result<(), FinalizationCryptoError> {
 		if self.is_finalized {
@@ -381,7 +378,6 @@ impl Blake2b {
 	}
 
 	#[must_use]
-	#[inline(always)]
 	/// Return a BLAKE2b digest.
 	pub fn finalize(&mut self) -> Result<Digest, FinalizationCryptoError> {
 		if self.is_finalized {
@@ -409,7 +405,6 @@ impl Blake2b {
 }
 
 #[must_use]
-#[inline(always)]
 #[allow(clippy::unreadable_literal)]
 /// Initialize a `Blake2b` struct with a given size and an optional key.
 pub fn init(secret_key: Option<&SecretKey>, size: usize) -> Result<Blake2b, UnknownCryptoError> {

--- a/src/hazardous/hash/sha512.rs
+++ b/src/hazardous/hash/sha512.rs
@@ -130,35 +130,35 @@ impl core::fmt::Debug for Sha512 {
 }
 
 impl Sha512 {
-	#[inline(always)]
+	#[inline]
 	/// The Ch function as specified in FIPS 180-4 section 4.1.3.
 	fn ch(&self, x: u64, y: u64, z: u64) -> u64 { z ^ (x & (y ^ z)) }
 
-	#[inline(always)]
+	#[inline]
 	/// The Maj function as specified in FIPS 180-4 section 4.1.3.
 	fn maj(&self, x: u64, y: u64, z: u64) -> u64 { (x & y) | (z & (x | y)) }
 
-	#[inline(always)]
+	#[inline]
 	/// The Big Sigma 0 function as specified in FIPS 180-4 section 4.1.3.
 	fn big_sigma_0(&self, x: u64) -> u64 {
 		(x.rotate_right(28)) ^ x.rotate_right(34) ^ x.rotate_right(39)
 	}
 
-	#[inline(always)]
+	#[inline]
 	/// The Big Sigma 1 function as specified in FIPS 180-4 section 4.1.3.
 	fn big_sigma_1(&self, x: u64) -> u64 {
 		(x.rotate_right(14)) ^ x.rotate_right(18) ^ x.rotate_right(41)
 	}
 
-	#[inline(always)]
+	#[inline]
 	/// The Small Sigma 0 function as specified in FIPS 180-4 section 4.1.3.
 	fn small_sigma_0(&self, x: u64) -> u64 { (x.rotate_right(1)) ^ x.rotate_right(8) ^ (x >> 7) }
 
-	#[inline(always)]
+	#[inline]
 	/// The Small Sigma 1 function as specified in FIPS 180-4 section 4.1.3.
 	fn small_sigma_1(&self, x: u64) -> u64 { (x.rotate_right(19)) ^ x.rotate_right(61) ^ (x >> 6) }
 
-	#[inline(always)]
+	#[inline]
 	#[allow(clippy::many_single_char_names)]
 	#[allow(clippy::too_many_arguments)]
 	/// Message compression adopted from [mbed TLS](https://tls.mbed.org/sha-512-source-code).
@@ -187,7 +187,7 @@ impl Sha512 {
 		*h = temp1.wrapping_add(temp2);
 	}
 
-	#[inline(always)]
+	#[inline]
 	#[rustfmt::skip]
 	#[allow(clippy::many_single_char_names)]
 	/// Process data in `self.buffer`.
@@ -244,7 +244,7 @@ impl Sha512 {
 		self.is_finalized = false;
 	}
 
-	#[inline(always)]
+	#[inline]
 	/// Increment the message length during processing of data.
 	fn increment_mlen(&mut self, length: u64) {
 		// left-shift to get bit-sized representation of length

--- a/src/hazardous/kdf/hkdf.rs
+++ b/src/hazardous/kdf/hkdf.rs
@@ -68,7 +68,6 @@ use crate::{
 };
 
 #[must_use]
-#[inline(always)]
 /// The HKDF extract step.
 pub fn extract(salt: &[u8], ikm: &[u8]) -> Result<hmac::Tag, UnknownCryptoError> {
 	let mut prk = hmac::init(&SecretKey::from_slice(salt)?);
@@ -78,7 +77,6 @@ pub fn extract(salt: &[u8], ikm: &[u8]) -> Result<hmac::Tag, UnknownCryptoError>
 }
 
 #[must_use]
-#[inline(always)]
 /// The HKDF expand step.
 pub fn expand(
 	prk: &hmac::Tag,

--- a/src/hazardous/kdf/pbkdf2.rs
+++ b/src/hazardous/kdf/pbkdf2.rs
@@ -82,7 +82,7 @@ construct_hmac_key! {
 	(Password, SHA2_BLOCKSIZE)
 }
 
-#[inline(always)]
+#[inline]
 /// The F function as described in the RFC.
 fn function_f(
 	salt: &[u8],
@@ -117,7 +117,6 @@ fn function_f(
 }
 
 #[must_use]
-#[inline(always)]
 /// PBKDF2-SHA512 (Password-Based Key Derivation Function 2) as specified in the
 /// [RFC 8018](https://tools.ietf.org/html/rfc8018).
 pub fn derive_key(

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -130,7 +130,7 @@ impl core::fmt::Debug for Hmac {
 }
 
 impl Hmac {
-	#[inline(always)]
+	#[inline]
 	/// Pad `key` with `ipad` and `opad`.
 	fn pad_key_io(&mut self, key: &SecretKey) {
 		let mut opad: BlocksizeArray = [0x5C; SHA2_BLOCKSIZE];
@@ -169,7 +169,6 @@ impl Hmac {
 	}
 
 	#[must_use]
-	#[inline(always)]
 	/// Return a `Tag`.
 	pub fn finalize(&mut self) -> Result<Tag, FinalizationCryptoError> {
 		if self.is_finalized {
@@ -190,7 +189,6 @@ impl Hmac {
 }
 
 #[must_use]
-#[inline(always)]
 /// Initialize `Hmac` struct with a given key.
 pub fn init(secret_key: &SecretKey) -> Hmac {
 	let mut state = Hmac {

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -228,7 +228,7 @@ impl Poly1305 {
         Ok(())
     }
 
-    #[rustfmt::skip]
+	#[rustfmt::skip]
     #[allow(clippy::cast_lossless)]
     #[allow(clippy::identity_op)]
     #[allow(clippy::unreadable_literal)]

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -119,7 +119,7 @@ impl core::fmt::Debug for Poly1305 {
 }
 
 impl Poly1305 {
-	#[inline(always)]
+	#[inline]
 	#[allow(clippy::unreadable_literal)]
 	/// Initialize `Poly1305` struct for a given key.
 	fn initialize(&mut self, key: &OneTimeKey) {
@@ -137,7 +137,6 @@ impl Poly1305 {
 	}
 
 	#[must_use]
-    #[inline(never)]
     #[rustfmt::skip]
     #[allow(clippy::cast_lossless)]
     #[allow(clippy::identity_op)]
@@ -229,7 +228,6 @@ impl Poly1305 {
         Ok(())
     }
 
-	#[inline(never)]
     #[rustfmt::skip]
     #[allow(clippy::cast_lossless)]
     #[allow(clippy::identity_op)]
@@ -291,7 +289,6 @@ impl Poly1305 {
         self.a[3] = h3;
     }
 
-	#[inline(always)]
 	/// Reset to `init()` state.
 	pub fn reset(&mut self) {
 		self.a = [0u32; 5];
@@ -301,7 +298,6 @@ impl Poly1305 {
 	}
 
 	#[must_use]
-	#[inline(always)]
 	/// Update state with a `data`. This can be called multiple times.
 	pub fn update(&mut self, data: &[u8]) -> Result<(), FinalizationCryptoError> {
 		if self.is_finalized {
@@ -345,7 +341,6 @@ impl Poly1305 {
 	}
 
 	#[must_use]
-	#[inline(always)]
 	/// Return a Poly1305 tag.
 	pub fn finalize(&mut self) -> Result<Tag, FinalizationCryptoError> {
 		if self.is_finalized {

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -142,7 +142,7 @@ impl Drop for InternalState {
 }
 
 impl InternalState {
-	#[inline(always)]
+	#[inline]
 	/// Perform a single round on index `x`, `y` and `z` with an
 	/// `n_bit_rotation` left-rotation.
 	fn round(&mut self, x: usize, y: usize, z: usize, n_bit_rotation: u32) {
@@ -151,7 +151,7 @@ impl InternalState {
 		self.state[y] = self.state[y].rotate_left(n_bit_rotation);
 	}
 
-	#[inline(always)]
+	#[inline]
 	/// ChaCha quarter round on a `InternalState`. Indexed by four `usize`s.
 	fn quarter_round(&mut self, x: usize, y: usize, z: usize, w: usize) {
 		self.round(x, w, y, 16);
@@ -160,7 +160,7 @@ impl InternalState {
 		self.round(z, y, w, 7);
 	}
 
-	#[inline(always)]
+	#[inline]
 	/// Performs 8 `quarter_round` function calls to process a inner block.
 	fn process_inner_block(&mut self) {
 		// Perform column rounds
@@ -176,7 +176,7 @@ impl InternalState {
 	}
 
 	#[must_use]
-	#[inline(always)]
+	#[inline]
 	/// Initialize either a ChaCha or HChaCha state with a `secret_key` and
 	/// `nonce`.
 	fn init_state(
@@ -209,7 +209,7 @@ impl InternalState {
 	}
 
 	#[must_use]
-	#[inline(always)]
+	#[inline]
 	/// Process either a ChaCha20 or HChaCha20 block.
 	fn process_block(
 		&mut self,
@@ -248,7 +248,7 @@ impl InternalState {
 	}
 
 	#[must_use]
-	#[inline(always)]
+	#[inline]
 	/// Serialize a keystream block of 16 u32's, into a little-endian byte
 	/// array.
 	fn serialize_block(

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -142,7 +142,7 @@ impl Drop for InternalState {
 }
 
 impl InternalState {
-	#[inline]
+	#[inline(always)]
 	/// Perform a single round on index `x`, `y` and `z` with an
 	/// `n_bit_rotation` left-rotation.
 	fn round(&mut self, x: usize, y: usize, z: usize, n_bit_rotation: u32) {
@@ -151,7 +151,7 @@ impl InternalState {
 		self.state[y] = self.state[y].rotate_left(n_bit_rotation);
 	}
 
-	#[inline]
+	#[inline(always)]
 	/// ChaCha quarter round on a `InternalState`. Indexed by four `usize`s.
 	fn quarter_round(&mut self, x: usize, y: usize, z: usize, w: usize) {
 		self.round(x, w, y, 16);
@@ -160,7 +160,7 @@ impl InternalState {
 		self.round(z, y, w, 7);
 	}
 
-	#[inline]
+	#[inline(always)]
 	/// Performs 8 `quarter_round` function calls to process a inner block.
 	fn process_inner_block(&mut self) {
 		// Perform column rounds
@@ -176,7 +176,7 @@ impl InternalState {
 	}
 
 	#[must_use]
-	#[inline]
+	#[inline(always)]
 	/// Initialize either a ChaCha or HChaCha state with a `secret_key` and
 	/// `nonce`.
 	fn init_state(
@@ -209,7 +209,7 @@ impl InternalState {
 	}
 
 	#[must_use]
-	#[inline]
+	#[inline(always)]
 	/// Process either a ChaCha20 or HChaCha20 block.
 	fn process_block(
 		&mut self,
@@ -248,7 +248,7 @@ impl InternalState {
 	}
 
 	#[must_use]
-	#[inline]
+	#[inline(always)]
 	/// Serialize a keystream block of 16 u32's, into a little-endian byte
 	/// array.
 	fn serialize_block(

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -28,7 +28,6 @@ use rand_os::OsRng;
 use subtle::ConstantTimeEq;
 
 #[must_use]
-#[inline(never)]
 #[cfg(feature = "safe_api")]
 /// Generate random bytes using a CSPRNG. Not available in `no_std` context.
 ///
@@ -70,7 +69,6 @@ pub fn secure_rand_bytes(dst: &mut [u8]) -> Result<(), errors::UnknownCryptoErro
 }
 
 #[must_use]
-#[inline(never)]
 /// Compare two equal length slices in constant time.
 ///
 /// # About:


### PR DESCRIPTION
Fixes #50.

This removes all `inline` attributes from public API's. Nearly all other `inline` attributes have been made `#[inline]` to not have the compiler make inline expansion every time, as with `#[inline(always)]`. Some internal functions still use `#[inline(always)]`, but only because benchmarks showed a significant regression when changed to `#[inline]`.

This improves compilation time and in some cases also performance.

`travis-ci.yml` has also been updated to test in both `src` and `tests` with ASan again. 