### PR TITLE
Switch form clear_on_drop to zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ exclude = [
 rand_os = { version = "0.1.2", optional = true }
 tiny-keccak = "1.4.2"
 subtle = { version = "2", default-features = false }
-clear_on_drop = "=0.2.3"
+zeroize = { version = "0.5.2", default-features = false }
 
 [features]
 default = [ "safe_api" ]
 safe_api = [ "rand_os" ]
-nightly = [ "clear_on_drop/nightly", "subtle/nightly", "safe_api" ]
-no_std = [ "clear_on_drop/nightly", "subtle/nightly" ]
+nightly = [ "subtle/nightly", "safe_api" ]
+no_std = [ "subtle/nightly" ]
 
 [dev-dependencies]
 hex = "0.3.2"

--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -73,7 +73,6 @@ use crate::{
 	errors::{FinalizationCryptoError, UnknownCryptoError, ValidationCryptoError},
 	hazardous::constants::{BLAKE2B_BLOCKSIZE, BLAKE2B_OUTSIZE},
 };
-use clear_on_drop::clear::Clear;
 
 construct_blake2b_key! {
 	/// A type to represent the `SecretKey` that BLAKE2b uses for keyed mode.
@@ -182,10 +181,10 @@ pub struct Blake2b {
 
 impl Drop for Blake2b {
 	fn drop(&mut self) {
-		use clear_on_drop::clear::Clear;
-		self.init_state.clear();
-		self.internal_state.clear();
-		self.buffer.clear();
+		use zeroize::Zeroize;
+		self.init_state.zeroize();
+		self.internal_state.zeroize();
+		self.buffer.zeroize();
 	}
 }
 
@@ -348,7 +347,6 @@ impl Blake2b {
 				self.buffer[self.leftover..(self.leftover + bytes.len())].copy_from_slice(&bytes);
 				// Using .unwrap() since overflow should not happen in practice
 				self.leftover = self.leftover.checked_add(bytes.len()).unwrap();
-				bytes.clear();
 				return Ok(());
 			}
 
@@ -373,8 +371,6 @@ impl Blake2b {
 			// Using .unwrap() since overflow should not happen in practice
 			self.leftover = self.leftover.checked_add(bytes.len()).unwrap();
 		}
-
-		bytes.clear();
 
 		Ok(())
 	}

--- a/src/hazardous/hash/sha512.rs
+++ b/src/hazardous/hash/sha512.rs
@@ -111,10 +111,10 @@ pub struct Sha512 {
 
 impl Drop for Sha512 {
 	fn drop(&mut self) {
-		use clear_on_drop::clear::Clear;
-		self.working_state.clear();
-		self.buffer.clear();
-		self.message_len.clear();
+		use zeroize::Zeroize;
+		self.working_state.zeroize();
+		self.buffer.zeroize();
+		self.message_len.zeroize();
 	}
 }
 

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -74,7 +74,7 @@ use crate::{
 		hash::sha512,
 	},
 };
-use clear_on_drop::clear::Clear;
+use zeroize::Zeroize;
 
 construct_hmac_key! {
 	/// A type to represent the `SecretKey` that HMAC uses for authentication.
@@ -139,8 +139,8 @@ impl Hmac {
 		self.ipad_hasher.update(ipad.as_ref()).unwrap();
 		self.opad_hasher.update(opad.as_ref()).unwrap();
 		self.working_hasher = self.ipad_hasher.clone();
-		ipad.clear();
-		opad.clear();
+		ipad.zeroize();
+		opad.zeroize();
 	}
 
 	/// Reset to `init()` state.

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -99,11 +99,11 @@ pub struct Poly1305 {
 
 impl Drop for Poly1305 {
 	fn drop(&mut self) {
-		use clear_on_drop::clear::Clear;
-		self.a.clear();
-		self.r.clear();
-		self.s.clear();
-		self.buffer.clear();
+		use zeroize::Zeroize;
+		self.a.zeroize();
+		self.r.zeroize();
+		self.s.zeroize();
+		self.buffer.zeroize();
 	}
 }
 

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -107,7 +107,7 @@ use crate::{
 		IETF_CHACHA_NONCESIZE,
 	},
 };
-use clear_on_drop::clear::Clear;
+use zeroize::Zeroize;
 
 construct_secret_key! {
 	/// A type to represent the `SecretKey` that `chacha20`, `xchacha20`, `chacha20poly1305` and
@@ -136,8 +136,8 @@ struct InternalState {
 
 impl Drop for InternalState {
 	fn drop(&mut self) {
-		use clear_on_drop::clear::Clear;
-		self.state.clear();
+		use zeroize::Zeroize;
+		self.state.zeroize();
 	}
 }
 
@@ -333,8 +333,8 @@ pub fn encrypt(
 		}
 	}
 
-	keystream_block.clear();
-	keystream_state.clear();
+	keystream_block.zeroize();
+	keystream_state.zeroize();
 
 	Ok(())
 }
@@ -371,7 +371,7 @@ pub fn keystream_block(
 
 	chacha_state.serialize_block(&keystream_state, &mut keystream_block)?;
 
-	keystream_state.clear();
+	keystream_state.zeroize();
 
 	Ok(keystream_block)
 }
@@ -393,7 +393,7 @@ pub fn hchacha20(
 	let mut keystream_block: [u8; HCHACHA_OUTSIZE] = [0u8; HCHACHA_OUTSIZE];
 	chacha_state.serialize_block(&keystream_state, &mut keystream_block)?;
 
-	keystream_state.clear();
+	keystream_state.zeroize();
 
 	Ok(keystream_block)
 }

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -77,7 +77,7 @@ use crate::{
 	errors::{UnknownCryptoError, ValidationCryptoError},
 	hazardous::kdf::pbkdf2,
 };
-use clear_on_drop::clear::Clear;
+use zeroize::Zeroize;
 
 #[must_use]
 /// Derive a key using PBKDF2-HMAC-SHA512.
@@ -101,7 +101,7 @@ pub fn derive_key(
 	)?;
 
 	let dk = SecretKey::from_slice(&buffer)?;
-	Clear::clear(&mut buffer);
+	buffer.zeroize();
 
 	Ok(dk)
 }
@@ -124,7 +124,7 @@ pub fn derive_key_verify(
 		&mut buffer,
 	)?;
 
-	Clear::clear(&mut buffer);
+	buffer.zeroize();
 
 	Ok(is_good)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
-extern crate clear_on_drop;
+extern crate zeroize;
 #[cfg(feature = "safe_api")]
 extern crate rand_os;
 extern crate subtle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,11 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
-extern crate zeroize;
 #[cfg(feature = "safe_api")]
 extern crate rand_os;
 extern crate subtle;
 extern crate tiny_keccak;
+extern crate zeroize;
 
 #[cfg(test)]
 #[cfg(feature = "safe_api")]

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -76,7 +76,7 @@ use crate::{
 	hazardous::kdf::pbkdf2,
 	util,
 };
-use clear_on_drop::clear::Clear;
+use zeroize::Zeroize;
 
 #[must_use]
 /// Hash a password using PBKDF2-HMAC-SHA512.
@@ -97,7 +97,7 @@ pub fn hash_password(
 	)?;
 
 	let dk = PasswordHash::from_slice(&buffer)?;
-	buffer.clear();
+	buffer.zeroize();
 
 	Ok(dk)
 }
@@ -119,7 +119,7 @@ pub fn hash_password_verify(
 		&mut dk,
 	)?;
 
-	dk.clear();
+	dk.zeroize();
 
 	Ok(is_good)
 }

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -91,27 +91,11 @@ macro_rules! impl_normal_debug_trait (($name:ident) => (
 /// destructor is called. WARNING: This requires value to be an array as
 /// clear_on_drop will not be called correctly if this particluar trait is
 /// implemented on Vec's.
-macro_rules! impl_drop_stack_trait (($name:ident) => (
+macro_rules! impl_drop_trait (($name:ident) => (
     impl Drop for $name {
         fn drop(&mut self) {
-            use clear_on_drop::clear::Clear;
-            self.value.clear();
-        }
-    }
-));
-
-#[cfg(feature = "safe_api")]
-/// Macro that implements the `Drop` trait on a object called `$name` which as a
-/// field `value`. This `Drop` will zero out the field `value` when the objects
-/// destructor is called. WARNING: This requires value to be a Vec as
-/// clear_on_drop, since calling clear_on_drop this way on arrays above the
-/// length of 32 will fail since they don't implement Default.
-macro_rules! impl_drop_heap_trait (($name:ident) => (
-    #[cfg(feature = "safe_api")]
-    impl Drop for $name {
-        fn drop(&mut self) {
-            use clear_on_drop::clear::Clear;
-            Clear::clear(&mut self.value);
+            use zeroize::Zeroize;
+            self.value.zeroize();
         }
     }
 ));
@@ -229,7 +213,7 @@ macro_rules! construct_secret_key {
         pub struct $name { value: [u8; $size] }
 
         impl_omitted_debug_trait!($name);
-        impl_drop_stack_trait!($name);
+        impl_drop_trait!($name);
         impl_ct_partialeq_trait!($name);
 
         impl $name {
@@ -439,7 +423,7 @@ macro_rules! construct_hmac_key {
         pub struct $name { value: [u8; $size] }
 
         impl_omitted_debug_trait!($name);
-        impl_drop_stack_trait!($name);
+        impl_drop_trait!($name);
         impl_ct_partialeq_trait!($name);
 
         impl $name {
@@ -528,7 +512,7 @@ macro_rules! construct_blake2b_key {
         }
 
         impl_omitted_debug_trait!($name);
-        impl_drop_stack_trait!($name);
+        impl_drop_trait!($name);
         impl_ct_partialeq_trait!($name);
 
         impl $name {
@@ -740,7 +724,7 @@ macro_rules! construct_secret_key_variable_size {
         pub struct $name { value: Vec<u8> }
 
         impl_omitted_debug_trait!($name);
-        impl_drop_heap_trait!($name);
+        impl_drop_trait!($name);
         impl_ct_partialeq_trait!($name);
         impl_default_trait!($name, $size);
 
@@ -864,7 +848,7 @@ macro_rules! construct_password_variable_size {
         pub struct $name { value: Vec<u8> }
 
         impl_omitted_debug_trait!($name);
-        impl_drop_heap_trait!($name);
+        impl_drop_trait!($name);
         impl_ct_partialeq_trait!($name);
 
         impl $name {


### PR DESCRIPTION
This will avoid needing a C compiler on stable Rust, since zeroize has no build-dependencies.