### PR TITLE
Rephrase "Exceptions" to "Errors" and add orion::hash to root docs

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -45,8 +45,8 @@
 //!   24 bytes being the nonce and the last
 //! 16 bytes being the corresponding Poly1305 tag.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `secret_key` is not 32 bytes.
 //! - `plaintext` is empty.
 //! - `plaintext` is longer than (2^32)-2.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -38,8 +38,8 @@
 //! - `data`: Data to be authenticated.
 //! - `expected`: The expected authentication tag.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - The calculated `Tag` does not match the expected.
 //!
 //! # Security:

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -35,8 +35,8 @@
 //! # Parameters:
 //! - `data`:  The data to be hashed.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //!
 //! # Security:
 //! - This interface does not support supplying BLAKE2b with a secret key, and

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -43,8 +43,8 @@
 //! because such a truncation may repeat after a short time." See [RFC](https://tools.ietf.org/html/rfc8439#section-3)
 //! for more information.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext + 16` when encrypting.
 //! - The length of `dst_out` is less than `ciphertext_with_tag - 16` when
 //!   decrypting.

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -36,8 +36,8 @@
 //! timestamps or monotonically increasing counters in order to discard previous
 //! messages and prevent replay attacks." See [libsodium docs](https://download.libsodium.org/doc/secret-key_cryptography/aead#additional-data) for more information.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext + 16` when encrypting.
 //! - The length of `dst_out` is less than `ciphertext_with_tag - 16` when
 //!   decrypting.

--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -26,8 +26,8 @@
 //! - `data`: The data to be hashed.
 //! - `expected`: The expected digest when verifying.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `size` is 0.
 //! - `size` is greater than 64.
 //! - `finalize()` is called twice without a `reset()` in between.

--- a/src/hazardous/hash/sha512.rs
+++ b/src/hazardous/hash/sha512.rs
@@ -23,8 +23,8 @@
 //! # Parameters:
 //! - `data`: The data to be hashed.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `finalize()` is called twice without a `reset()` in between.
 //! - `update()` is called after `finalize()` without a `reset()` in between.
 //!

--- a/src/hazardous/kdf/hkdf.rs
+++ b/src/hazardous/kdf/hkdf.rs
@@ -29,8 +29,8 @@
 //!   derived key is implied by the length of `okm_out`.
 //! - `expected`: The expected derived key.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - The length of `dst_out` is less than 1.
 //! - The length of `dst_out` is greater than 255 * hash_output_size_in_bytes.
 //! - The derived key does not match the expected when verifying.

--- a/src/hazardous/kdf/pbkdf2.rs
+++ b/src/hazardous/kdf/pbkdf2.rs
@@ -28,8 +28,8 @@
 //!   derived key is implied by the length of `dk_out`.
 //! - `expected`: The expected derived key.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - The length of `dst_out` is less than 1.
 //! - The length of `dst_out` is greater than (2^32 - 1) * 64.
 //! - The specified iteration count is less than 1.

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -25,8 +25,8 @@
 //! - `data`: Data to be authenticated.
 //! - `expected`: The expected authentication tag.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `finalize()` is called twice without a `reset()` in between.
 //! - `update()` is called after `finalize()` without a `reset()` in between.
 //! - The HMAC does not match the expected when verifying.

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -30,8 +30,8 @@
 //! - `one_time_key`: One-time key used to authenticate.
 //! - `expected`: The expected tag that needs to be verified.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `finalize()` is called twice without a `reset()` in between.
 //! - `update()` is called after `finalize()` without a `reset()` in between.
 //! - The calculated tag does not match the expected when verifying.

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -36,8 +36,8 @@
 //! because such a truncation may repeat after a short time." See [RFC](https://tools.ietf.org/html/rfc8439)
 //! for more information.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `slice` when calling `SecretKey::from_slice()` is not 32 bytes.
 //! - The `OsRng` fails to initialize or read from its source when calling
 //!   `SecretKey::generate()`.

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -29,8 +29,8 @@
 //! - `dst_out`: Destination array that will hold the ciphertext/plaintext after
 //!   encryption/decryption.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` or `ciphertext`.
 //! - `plaintext` or `ciphertext` is empty.
 //! - `plaintext` or `ciphertext` is longer than (2^32)-2.

--- a/src/hazardous/xof/cshake.rs
+++ b/src/hazardous/xof/cshake.rs
@@ -41,8 +41,8 @@
 //! The cSHAKE256 implementation currently relies on the `tiny-keccak` crate.
 //! Currently, this crate will produce ***incorrect results on big-endian based systems***. See the [issue here](https://github.com/debris/tiny-keccak/issues/15).
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - The length of `dst_out` is zero.
 //! - The length of `dst_out` is greater than 65536.
 //! - `finalize()` is called twice in a row without calling `reset()` in

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -44,8 +44,8 @@
 //!   parameter.
 //! - `length`: The desired length of the derived key.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `iterations` is 0.
 //! - `length` is 0.
 //! - `length` is not less than `u32::max_value()`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
 //! ## Message authentication
 //! `orion::auth` offers message authentication and verification using HMAC.
 //!
+//! ## Hashing
+//! `orion::hash` offers hashing using BLAKE2b.
 //!
 //! ### A note on `no_std`:
 //! When orion is used in a `no_std` context, access to nearly all functionality

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -48,8 +48,8 @@
 //! - `iterations`: The number of iterations performed by PBKDF2, i.e. the cost
 //!   parameter.
 //!
-//! # Exceptions:
-//! An exception will be thrown if:
+//! # Errors:
+//! An error will be returned if:
 //! - `iterations` is 0.
 //! - The `OsRng` fails to initialize or read from its source.
 //! - The `expected_with_salt` is not constructed exactly as in

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -44,8 +44,8 @@ use subtle::ConstantTimeEq;
 ///   bytes to be generated is
 /// implied by the length of `dst`.
 ///
-/// # Exceptions:
-/// An exception will be thrown if:
+/// # Errors:
+/// An error will be returned if:
 /// - The `OsRng` fails to initialize or read from its source.
 /// - `dst` is empty.
 ///
@@ -79,8 +79,8 @@ pub fn secure_rand_bytes(dst: &mut [u8]) -> Result<(), errors::UnknownCryptoErro
 /// - `a`: The first slice used in the comparison.
 /// - `b`: The second slice used in the comparison.
 ///
-/// # Exceptions:
-/// An exception will be thrown if:
+/// # Errors:
+/// An error will be returned if:
 /// - `a` and `b` do not have the same length.
 /// - `a` is not equal to `b`.
 ///


### PR DESCRIPTION
Fixes #60.