### PR TITLE
Correct size-limitation on input bytes to ChaCha20

### DIFF
--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -50,7 +50,6 @@
 //!   decrypting.
 //! - The length of `ciphertext_with_tag` is not greater than `16`.
 //! - `plaintext` or `ciphertext_with_tag` are empty.
-//! - `plaintext` or `ciphertext_with_tag - 16` are longer than (2^32)-2.
 //! - The received tag does not match the calculated tag when decrypting.
 //!
 //! # Security:

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -52,6 +52,10 @@
 //! - `plaintext` or `ciphertext_with_tag` are empty.
 //! - The received tag does not match the calculated tag when decrypting.
 //!
+//! # Panics:
+//! A panic will occur if:
+//! - More than 2^32-1 * 64 bytes of data are processed.
+//!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
 //!   key. Should this happen,

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -43,8 +43,11 @@
 //!   decrypting.
 //! - The length of `ciphertext_with_tag` is not greater than `16`.
 //! - `plaintext` or `ciphertext_with_tag` are empty.
-//! - `plaintext` or `ciphertext_with_tag - 16` are longer than (2^32)-2.
 //! - The received tag does not match the calculated tag when decrypting.
+//!
+//! # Panics:
+//! A panic will occur if:
+//! - More than 2^32-1 * 64 bytes of data are processed.
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -43,7 +43,6 @@
 //!   `SecretKey::generate()`.
 //! - The length of `dst_out` is less than `plaintext` or `ciphertext`.
 //! - `plaintext` or `ciphertext` are empty.
-//! - `plaintext` or `ciphertext` are longer than (2^32)-2.
 //! - The `initial_counter` is high enough to cause a potential overflow.
 //!
 //! Even though `dst_out` is allowed to be of greater length than `plaintext`,
@@ -300,12 +299,6 @@ pub fn encrypt(
 	// encrypts an empty plaintext, they might think the plaintext wasn't empty
 	// when checking data in `dst_ciphertext` after encryption
 	if plaintext.is_empty() {
-		return Err(UnknownCryptoError);
-	}
-	// Check data limitation for secret_key,nonce combination at max is (2^32)-2
-	if plaintext.len() as u32 == u32::max_value() {
-		// `usize::max_value() as u32` == `u32::max_value()` so we have to compare
-		// equals
 		return Err(UnknownCryptoError);
 	}
 

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -49,6 +49,10 @@
 //! Even though `dst_out` is allowed to be of greater length than `plaintext`,
 //! the `ciphertext` produced by `chacha20`/`xchacha20` will always be of the
 //! same length as the `plaintext`.
+//! 
+//! # Panics:
+//! A panic will occur if:
+//! - More than 2^32-1 keystream blocks are processed.
 //!
 //! ### Note:
 //! `keystream_block()` is for use-cases where more control over the keystream
@@ -131,6 +135,7 @@ construct_nonce_no_generator! {
 #[derive(Clone)]
 struct InternalState {
 	state: ChaChaState,
+	internal_counter: u32,
 	is_ietf: bool,
 }
 
@@ -222,6 +227,10 @@ impl InternalState {
 			return Err(UnknownCryptoError);
 		}
 
+		// If this panics, max amount of keystream blocks
+		// have been retrieved.
+		self.internal_counter.checked_add(1).unwrap();
+
 		// Only set block counter if not HChaCha
 		if self.is_ietf {
 			// .unwrap() cannot panic here since the above two
@@ -302,6 +311,7 @@ pub fn encrypt(
 
 	let mut chacha_state = InternalState {
 		state: [0_u32; 16],
+		internal_counter: 0,
 		is_ietf: true,
 	};
 
@@ -362,6 +372,7 @@ pub fn keystream_block(
 ) -> Result<[u8; CHACHA_BLOCKSIZE], UnknownCryptoError> {
 	let mut chacha_state = InternalState {
 		state: [0_u32; 16],
+		internal_counter: 0,
 		is_ietf: true,
 	};
 	chacha_state.init_state(secret_key, &nonce.as_bytes())?;
@@ -385,6 +396,7 @@ pub fn hchacha20(
 ) -> Result<[u8; HCHACHA_OUTSIZE], UnknownCryptoError> {
 	let mut chacha_state = InternalState {
 		state: [0_u32; 16],
+		internal_counter: 0,
 		is_ietf: false,
 	};
 	chacha_state.init_state(secret_key, nonce)?;
@@ -833,6 +845,7 @@ mod private {
 		fn test_nonce_length() {
 			let mut chacha_state = InternalState {
 				state: [0_u32; 16],
+				internal_counter: 0,
 				is_ietf: true,
 			};
 
@@ -848,6 +861,7 @@ mod private {
 
 			let mut hchacha_state = InternalState {
 				state: [0_u32; 16],
+				internal_counter: 0,
 				is_ietf: false,
 			};
 
@@ -873,6 +887,7 @@ mod private {
 				fn prop_test_nonce_length_ietf(nonce: Vec<u8>) -> bool {
 					let mut chacha_state_ietf = InternalState {
 						state: [0_u32; 16],
+						internal_counter: 0,
 						is_ietf: true,
 					};
 
@@ -906,6 +921,7 @@ mod private {
 				fn prop_test_nonce_length_hchacha(nonce: Vec<u8>) -> bool {
 					let mut chacha_state_hchacha = InternalState {
 						state: [0_u32; 16],
+						internal_counter: 0,
 						is_ietf: false,
 					};
 
@@ -941,6 +957,7 @@ mod private {
 		fn test_process_block_wrong_combination_of_variant_and_nonce() {
 			let mut chacha_state_ietf = InternalState {
 				state: [0_u32; 16],
+				internal_counter: 0,
 				is_ietf: true,
 			};
 			chacha_state_ietf
@@ -949,6 +966,7 @@ mod private {
 
 			let mut chacha_state_hchacha = InternalState {
 				state: [0_u32; 16],
+				internal_counter: 0,
 				is_ietf: false,
 			};
 
@@ -970,6 +988,7 @@ mod private {
 		fn test_wrong_combination_of_variant_and_dst_out() {
 			let mut chacha_state_ietf = InternalState {
 				state: [0_u32; 16],
+				internal_counter: 0,
 				is_ietf: true,
 			};
 
@@ -979,6 +998,7 @@ mod private {
 
 			let mut chacha_state_hchacha = InternalState {
 				state: [0_u32; 16],
+				internal_counter: 0,
 				is_ietf: false,
 			};
 
@@ -1017,6 +1037,7 @@ mod test_vectors {
 	fn init(key: &[u8], nonce: &[u8]) -> Result<InternalState, UnknownCryptoError> {
 		let mut chacha_state = InternalState {
 			state: [0_u32; 16],
+			internal_counter: 0,
 			is_ietf: true,
 		};
 
@@ -1035,6 +1056,7 @@ mod test_vectors {
 				0x01234567, 0x11111111, 0x01020304, 0x9b8d6f43, 0x01234567, 0x11111111, 0x01020304,
 				0x9b8d6f43, 0x01234567,
 			],
+			internal_counter: 0,
 			is_ietf: true,
 		};
 		let expected: [u32; 4] = [0xea2a92f4, 0xcb1cf8ce, 0x4581472e, 0x5881c4bb];
@@ -1058,6 +1080,7 @@ mod test_vectors {
 				0x2a5f714c, 0x53372767, 0xb00a5631, 0x974c541a, 0x359e9963, 0x5c971061, 0x3d631689,
 				0x2098d9d6, 0x91dbd320,
 			],
+			internal_counter: 0,
 			is_ietf: true,
 		};
 		let expected: ChaChaState = [

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -33,7 +33,6 @@
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` or `ciphertext`.
 //! - `plaintext` or `ciphertext` is empty.
-//! - `plaintext` or `ciphertext` is longer than (2^32)-2.
 //! - The `initial_counter` is high enough to cause a potential overflow.
 //!
 //! Even though `dst_out` is allowed to be of greater length than `plaintext`,

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -39,6 +39,10 @@
 //! the `ciphertext` produced by `chacha20`/`xchacha20` will always be of the
 //! same length as the `plaintext`.
 //!
+//! # Panics:
+//! A panic will occur if:
+//! - More than 2^32-1 * 64 bytes of data are processed.
+//! 
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
 //!   key. Should this happen,


### PR DESCRIPTION
Currently ChaCha20 doesn't allow `plaintext` input parameters above `u32::max_value()` but the RFC defines the input restriction on a secret key/nonce combination as 2^32 blocks, meaning 2^32 * 64 bytes worth of data ([RFC section 2.3](https://tools.ietf.org/html/rfc8439#section-2.3)). 

This adds an internal counter to the internal ChaCha20 state, to check for the size restriction of 2^32 - 1 * 64 and panics if it is violated.

This size restriction also applies to XChaCha20, ChaCha20Poly1305 and XChaCha20Poly1305.