### PR TITLE
Reduce memory footprint

### DIFF
--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -227,16 +227,7 @@ impl Blake2b {
 	#[allow(clippy::many_single_char_names)]
 	#[allow(clippy::too_many_arguments)]
 	/// The primitive mixing function G as defined in the RFC.
-	fn prim_mix_g(
-		&mut self,
-		x: u64,
-		y: u64,
-		a: usize,
-		b: usize,
-		c: usize,
-		d: usize,
-		w: &mut [u64],
-	) {
+	fn prim_mix_g(x: u64, y: u64, a: usize, b: usize, c: usize, d: usize, w: &mut [u64]) {
 		w[a] = w[a].wrapping_add(w[b]).wrapping_add(x);
 		w[d] ^= w[a];
 		w[d] = (w[d]).rotate_right(32u32);
@@ -253,15 +244,15 @@ impl Blake2b {
 
 	#[inline(always)]
 	/// Perform a single round based on a message schedule selection.
-	fn round(&mut self, ri: usize, m: &mut [u64], w: &mut [u64]) {
-		self.prim_mix_g(m[SIGMA[ri][0]], m[SIGMA[ri][1]], 0, 4, 8, 12, w);
-		self.prim_mix_g(m[SIGMA[ri][2]], m[SIGMA[ri][3]], 1, 5, 9, 13, w);
-		self.prim_mix_g(m[SIGMA[ri][4]], m[SIGMA[ri][5]], 2, 6, 10, 14, w);
-		self.prim_mix_g(m[SIGMA[ri][6]], m[SIGMA[ri][7]], 3, 7, 11, 15, w);
-		self.prim_mix_g(m[SIGMA[ri][8]], m[SIGMA[ri][9]], 0, 5, 10, 15, w);
-		self.prim_mix_g(m[SIGMA[ri][10]], m[SIGMA[ri][11]], 1, 6, 11, 12, w);
-		self.prim_mix_g(m[SIGMA[ri][12]], m[SIGMA[ri][13]], 2, 7, 8, 13, w);
-		self.prim_mix_g(m[SIGMA[ri][14]], m[SIGMA[ri][15]], 3, 4, 9, 14, w);
+	fn round(ri: usize, m: &mut [u64; 16], w: &mut [u64; 16]) {
+		Self::prim_mix_g(m[SIGMA[ri][0]], m[SIGMA[ri][1]], 0, 4, 8, 12, w);
+		Self::prim_mix_g(m[SIGMA[ri][2]], m[SIGMA[ri][3]], 1, 5, 9, 13, w);
+		Self::prim_mix_g(m[SIGMA[ri][4]], m[SIGMA[ri][5]], 2, 6, 10, 14, w);
+		Self::prim_mix_g(m[SIGMA[ri][6]], m[SIGMA[ri][7]], 3, 7, 11, 15, w);
+		Self::prim_mix_g(m[SIGMA[ri][8]], m[SIGMA[ri][9]], 0, 5, 10, 15, w);
+		Self::prim_mix_g(m[SIGMA[ri][10]], m[SIGMA[ri][11]], 1, 6, 11, 12, w);
+		Self::prim_mix_g(m[SIGMA[ri][12]], m[SIGMA[ri][13]], 2, 7, 8, 13, w);
+		Self::prim_mix_g(m[SIGMA[ri][14]], m[SIGMA[ri][15]], 3, 4, 9, 14, w);
 	}
 
 	#[allow(clippy::needless_range_loop)]
@@ -288,18 +279,18 @@ impl Blake2b {
 			self.f[1] ^ IV[7],
 		];
 
-		self.round(0, &mut m_vec, &mut w_vec);
-		self.round(1, &mut m_vec, &mut w_vec);
-		self.round(2, &mut m_vec, &mut w_vec);
-		self.round(3, &mut m_vec, &mut w_vec);
-		self.round(4, &mut m_vec, &mut w_vec);
-		self.round(5, &mut m_vec, &mut w_vec);
-		self.round(6, &mut m_vec, &mut w_vec);
-		self.round(7, &mut m_vec, &mut w_vec);
-		self.round(8, &mut m_vec, &mut w_vec);
-		self.round(9, &mut m_vec, &mut w_vec);
-		self.round(10, &mut m_vec, &mut w_vec);
-		self.round(11, &mut m_vec, &mut w_vec);
+		Self::round(0, &mut m_vec, &mut w_vec);
+		Self::round(1, &mut m_vec, &mut w_vec);
+		Self::round(2, &mut m_vec, &mut w_vec);
+		Self::round(3, &mut m_vec, &mut w_vec);
+		Self::round(4, &mut m_vec, &mut w_vec);
+		Self::round(5, &mut m_vec, &mut w_vec);
+		Self::round(6, &mut m_vec, &mut w_vec);
+		Self::round(7, &mut m_vec, &mut w_vec);
+		Self::round(8, &mut m_vec, &mut w_vec);
+		Self::round(9, &mut m_vec, &mut w_vec);
+		Self::round(10, &mut m_vec, &mut w_vec);
+		Self::round(11, &mut m_vec, &mut w_vec);
 
 		// XOR the two halves together and into the state
 		self.internal_state[0] ^= w_vec[0] ^ w_vec[8];

--- a/src/hazardous/hash/sha512.rs
+++ b/src/hazardous/hash/sha512.rs
@@ -150,15 +150,11 @@ impl Sha512 {
 
 	#[inline]
 	/// The Big Sigma 0 function as specified in FIPS 180-4 section 4.1.3.
-	fn big_sigma_0(x: u64) -> u64 {
-		(x.rotate_right(28)) ^ x.rotate_right(34) ^ x.rotate_right(39)
-	}
+	fn big_sigma_0(x: u64) -> u64 { (x.rotate_right(28)) ^ x.rotate_right(34) ^ x.rotate_right(39) }
 
 	#[inline]
 	/// The Big Sigma 1 function as specified in FIPS 180-4 section 4.1.3.
-	fn big_sigma_1(x: u64) -> u64 {
-		(x.rotate_right(14)) ^ x.rotate_right(18) ^ x.rotate_right(41)
-	}
+	fn big_sigma_1(x: u64) -> u64 { (x.rotate_right(14)) ^ x.rotate_right(18) ^ x.rotate_right(41) }
 
 	#[inline]
 	/// The Small Sigma 0 function as specified in FIPS 180-4 section 4.1.3.

--- a/src/hazardous/hash/sha512.rs
+++ b/src/hazardous/hash/sha512.rs
@@ -142,38 +142,37 @@ impl core::fmt::Debug for Sha512 {
 impl Sha512 {
 	#[inline]
 	/// The Ch function as specified in FIPS 180-4 section 4.1.3.
-	fn ch(&self, x: u64, y: u64, z: u64) -> u64 { z ^ (x & (y ^ z)) }
+	fn ch(x: u64, y: u64, z: u64) -> u64 { z ^ (x & (y ^ z)) }
 
 	#[inline]
 	/// The Maj function as specified in FIPS 180-4 section 4.1.3.
-	fn maj(&self, x: u64, y: u64, z: u64) -> u64 { (x & y) | (z & (x | y)) }
+	fn maj(x: u64, y: u64, z: u64) -> u64 { (x & y) | (z & (x | y)) }
 
 	#[inline]
 	/// The Big Sigma 0 function as specified in FIPS 180-4 section 4.1.3.
-	fn big_sigma_0(&self, x: u64) -> u64 {
+	fn big_sigma_0(x: u64) -> u64 {
 		(x.rotate_right(28)) ^ x.rotate_right(34) ^ x.rotate_right(39)
 	}
 
 	#[inline]
 	/// The Big Sigma 1 function as specified in FIPS 180-4 section 4.1.3.
-	fn big_sigma_1(&self, x: u64) -> u64 {
+	fn big_sigma_1(x: u64) -> u64 {
 		(x.rotate_right(14)) ^ x.rotate_right(18) ^ x.rotate_right(41)
 	}
 
 	#[inline]
 	/// The Small Sigma 0 function as specified in FIPS 180-4 section 4.1.3.
-	fn small_sigma_0(&self, x: u64) -> u64 { (x.rotate_right(1)) ^ x.rotate_right(8) ^ (x >> 7) }
+	fn small_sigma_0(x: u64) -> u64 { (x.rotate_right(1)) ^ x.rotate_right(8) ^ (x >> 7) }
 
 	#[inline]
 	/// The Small Sigma 1 function as specified in FIPS 180-4 section 4.1.3.
-	fn small_sigma_1(&self, x: u64) -> u64 { (x.rotate_right(19)) ^ x.rotate_right(61) ^ (x >> 6) }
+	fn small_sigma_1(x: u64) -> u64 { (x.rotate_right(19)) ^ x.rotate_right(61) ^ (x >> 6) }
 
 	#[inline]
 	#[allow(clippy::many_single_char_names)]
 	#[allow(clippy::too_many_arguments)]
 	/// Message compression adopted from [mbed TLS](https://tls.mbed.org/sha-512-source-code).
 	fn compress(
-		&self,
 		a: u64,
 		b: u64,
 		c: u64,
@@ -186,12 +185,12 @@ impl Sha512 {
 		ki: u64,
 	) {
 		let temp1 = h
-			.wrapping_add(self.big_sigma_1(e))
-			.wrapping_add(self.ch(e, f, g))
+			.wrapping_add(Self::big_sigma_1(e))
+			.wrapping_add(Self::ch(e, f, g))
 			.wrapping_add(ki)
 			.wrapping_add(x);
 
-		let temp2 = self.big_sigma_0(a).wrapping_add(self.maj(a, b, c));
+		let temp2 = Self::big_sigma_0(a).wrapping_add(Self::maj(a, b, c));
 
 		*d = d.wrapping_add(temp1);
 		*h = temp1.wrapping_add(temp2);
@@ -206,10 +205,9 @@ impl Sha512 {
 		load_u64_into_be(&self.buffer, &mut w[..16]);
 
 		for t in 16..80 {
-			w[t] = self
-				.small_sigma_1(w[t - 2])
+			w[t] = Self::small_sigma_1(w[t - 2])
 				.wrapping_add(w[t - 7])
-				.wrapping_add(self.small_sigma_0(w[t - 15]))
+				.wrapping_add(Self::small_sigma_0(w[t - 15]))
 				.wrapping_add(w[t - 16]);
 		}
 
@@ -225,14 +223,14 @@ impl Sha512 {
 
 		let mut t = 0;
 		while t < 80 {
-			self.compress(a, b, c, &mut d, e, f, g, &mut h, w[t], K[t]); t += 1;
-			self.compress(h, a, b, &mut c, d, e, f, &mut g, w[t], K[t]); t += 1;
-			self.compress(g, h, a, &mut b, c, d, e, &mut f, w[t], K[t]); t += 1;
-			self.compress(f, g, h, &mut a, b, c, d, &mut e, w[t], K[t]); t += 1;
-			self.compress(e, f, g, &mut h, a, b, c, &mut d, w[t], K[t]); t += 1;
-			self.compress(d, e, f, &mut g, h, a, b, &mut c, w[t], K[t]); t += 1;
-			self.compress(c, d, e, &mut f, g, h, a, &mut b, w[t], K[t]); t += 1;
-			self.compress(b, c, d, &mut e, f, g, h, &mut a, w[t], K[t]); t += 1;
+			Self::compress(a, b, c, &mut d, e, f, g, &mut h, w[t], K[t]); t += 1;
+			Self::compress(h, a, b, &mut c, d, e, f, &mut g, w[t], K[t]); t += 1;
+			Self::compress(g, h, a, &mut b, c, d, e, &mut f, w[t], K[t]); t += 1;
+			Self::compress(f, g, h, &mut a, b, c, d, &mut e, w[t], K[t]); t += 1;
+			Self::compress(e, f, g, &mut h, a, b, c, &mut d, w[t], K[t]); t += 1;
+			Self::compress(d, e, f, &mut g, h, a, b, &mut c, w[t], K[t]); t += 1;
+			Self::compress(c, d, e, &mut f, g, h, a, &mut b, w[t], K[t]); t += 1;
+			Self::compress(b, c, d, &mut e, f, g, h, &mut a, w[t], K[t]); t += 1;
 		}
 
 		self.working_state[0] = self.working_state[0].wrapping_add(a);

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -327,13 +327,14 @@ pub fn encrypt(
 	{
 		match initial_counter.checked_add(counter as u32) {
 			Some(ref block_counter) => {
-
 				keystream_state = chacha_state.process_block(Some(*block_counter))?;
 				// We only want to allocate a `keystream_block` if the `ciphertext_block`
 				// is not long enough to hold the entire serialized keystream.
 				if ciphertext_block.len() == CHACHA_BLOCKSIZE {
 					chacha_state.serialize_block(&keystream_state, ciphertext_block)?;
-					for (ct_keystream, plaintext) in ciphertext_block.iter_mut().zip(plaintext_block.iter()) {
+					for (ct_keystream, plaintext) in
+						ciphertext_block.iter_mut().zip(plaintext_block.iter())
+					{
 						*ct_keystream ^= plaintext;
 					}
 				} else {
@@ -345,7 +346,7 @@ pub fn encrypt(
 						// due to chunks(), so indexing is no problem here
 						ciphertext_block[idx] = keystream_block[idx] ^ itm;
 					}
-					
+
 					keystream_block.zeroize();
 				}
 			}


### PR DESCRIPTION
Only allocate a `keystream_block` if the `ciphertext_block` is not long enough to hold the entire serialized keystream. This also merges the previous `round` function into `quarter_round` and removes some unneeded mutable `self` references in context structs of both Sha512, ChaCha20 and Blake2b.

Benchmarks report a ~30% performance increase in ChaCha20/XChaCha20 and ~20% in ChaCha20Poly1305/XChaCha20Poly1305.