### PR TITLE
Implement PartialEq<&[u8]> for newtypes

### DIFF
--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -43,8 +43,8 @@ macro_rules! impl_default_trait (($name:ident, $size:expr) => (
 ));
 
 /// Macro that implements the `PartialEq` trait on a object called `$name` that
-/// provides a given $bytes_function to return a slice. This `PartialEq` will perform in
-/// constant time.
+/// provides a given $bytes_function to return a slice. This `PartialEq` will
+/// perform in constant time.
 macro_rules! impl_ct_partialeq_trait (($name:ident, $bytes_function:ident) => (
     impl core::cmp::PartialEq<$name> for $name {
         fn eq(&self, other: &$name) -> bool {
@@ -255,7 +255,7 @@ macro_rules! test_partial_eq (($name:ident, $upper_bound:expr) => (
     #[test]
     fn test_partial_eq() {
         assert!($name::from_slice(&[0u8; $upper_bound]).unwrap() == $name::from_slice(&[0u8; $upper_bound]).unwrap());
-        assert!($name::from_slice(&[0u8; $upper_bound]).unwrap() != $name::from_slice(&[1u8; $upper_bound]).unwrap()); 
+        assert!($name::from_slice(&[0u8; $upper_bound]).unwrap() != $name::from_slice(&[1u8; $upper_bound]).unwrap());
 
         assert!($name::from_slice(&[0u8; $upper_bound]).unwrap() == [0u8; $upper_bound].as_ref());
         assert!($name::from_slice(&[0u8; $upper_bound]).unwrap() != [1u8; $upper_bound].as_ref());
@@ -615,7 +615,7 @@ macro_rules! construct_hmac_key {
         #[test]
         fn test_partial_eq() {
             assert!($name::from_slice(&[0u8; $size]).unwrap() == $name::from_slice(&[0u8; $size]).unwrap());
-            assert!($name::from_slice(&[0u8; $size]).unwrap() != $name::from_slice(&[1u8; $size]).unwrap()); 
+            assert!($name::from_slice(&[0u8; $size]).unwrap() != $name::from_slice(&[1u8; $size]).unwrap());
 
             assert!($name::from_slice(&[0u8; $size]).unwrap() == [0u8; $size].as_ref());
             assert!($name::from_slice(&[0u8; $size]).unwrap() != [1u8; $size].as_ref());

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -178,6 +178,7 @@ macro_rules! func_from_slice_variable_size (($name:ident) => (
 /// implement extra protections. Typically used on objects that implement
 /// `Drop`, `Debug` and/or `PartialEq`.
 macro_rules! func_unprotected_as_bytes (() => (
+    #[inline]
     #[must_use]
     /// Return the object as byte slice. __**Warning**__: Should not be used unless strictly
     /// needed. This __**breaks protections**__ that the type implements.


### PR DESCRIPTION
This PR implements `PartialEq<&[u8]>` for all newtypes in constant-time. This is to avoid situations where users would compare against another slice(`==`) while calling the newtype's `unprotected_as_bytes()` function. This could happen in situations where users want to avoid creating a new instance of a newtype just to be able to compare with the currently provided `PartialEq` implementation.

TODO:
- [DONE [here](https://github.com/brycx/orion-fuzz/tree/pteq-slice), should be merged with this PR] Add tests in orion-fuzz
- [DONE [here](https://github.com/brycx/orion-dudect/tree/pteq-slice), should be merged with this PR] Add tests in orion-dudect
- [See #77] Add short example in docs of relevant newtypes and a accompanying security note