### PR TITLE
Document newtype PartialEq usage 

### DIFF
--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -622,7 +622,7 @@ macro_rules! construct_hmac_key {
         /// let secret_key = SecretKey::generate();
         ///
         /// // Secure, costant-time comparison with byte slice
-        /// assert!(secret_key != key_bytes);
+        /// assert!(secret_key != &[0; 32][..]);
         /// ```
         pub struct $name {
             value: [u8; $size],

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -405,12 +405,10 @@ macro_rules! construct_secret_key {
         /// use orion::hazardous::stream::chacha20::SecretKey;
         ///
         /// // Initialize a secret key with 32 random bytes.
-        /// let key_bytes: [u8; 32] =
-        ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
-        ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
-        ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
-        ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
-        /// let secret_key = SecretKey::from_slice(&key_bytes).unwrap();
+        /// let secret_key = SecretKey::generate();
+        ///
+        /// // Get the byte slice out of the key to demonstrate the comparison.
+        /// let key_bytes = secret_key.unprotected_as_bytes();
         ///
         /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
         /// assert!(secret_key.unprotected_as_bytes() == key_bytes);
@@ -565,23 +563,11 @@ macro_rules! construct_tag {
         /// ```rust
         /// use orion::hazardous::mac::hmac::Tag;
         ///
-        /// // Initialize a tag with 64 random bytes.
-        /// let tag_bytes: [u8; 64] =
-        ///     [0x15, 0xf2, 0x52, 0x22, 0x01, 0x4c, 0x01, 0x85,
-        ///      0x6d, 0xe3, 0xb4, 0x94, 0x09, 0x9a, 0xe8, 0x28,
-        ///      0xf1, 0x61, 0xc8, 0xbc, 0x57, 0x2e, 0xa3, 0x1a,
-        ///      0x49, 0x1f, 0x79, 0x84, 0x93, 0x49, 0x68, 0xab,
-        ///      0xb2, 0xc8, 0xf1, 0xa7, 0xa6, 0xbc, 0x4d, 0x60,
-        ///      0x09, 0x91, 0x50, 0x22, 0xd5, 0xf9, 0xa1, 0x80,
-        ///      0x46, 0x25, 0x3c, 0x2e, 0x76, 0x79, 0xaa, 0xa1,
-        ///      0x84, 0x95, 0x70, 0x20, 0xf2, 0xfd, 0xe5, 0x16];
-        /// let tag = Tag::from_slice(&tag_bytes).unwrap();
+        /// // Initialize an arbitrary, 64-byte tag.
+        /// let tag = Tag::from_slice(&[1; 64]).unwrap();
         ///
-        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
-        /// assert!(tag.unprotected_as_bytes() == &tag_bytes[..]);
-        ///
-        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
-        /// assert!(tag == &tag_bytes[..]);
+        /// // Constant-time comparison
+        /// assert!(tag == &[1; 64][..]);
         /// ```
         pub struct $name {
             value: [u8; $upper_bound],
@@ -639,23 +625,16 @@ macro_rules! construct_hmac_key {
         /// use orion::hazardous::mac::hmac::SecretKey;
         ///
         /// // Initialize a secret key with 32 random bytes.
-        /// let key_bytes: [u8; 32] =
-        ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
-        ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
-        ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
-        ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
-        /// let secret_key = SecretKey::from_slice(&key_bytes).unwrap();
-        ///
-        /// // The `SecretKey::from_slice` function pads the key,
-        /// // so we need to get a new slice for comparisons. Admittedly,
-        /// // this does make the insecure example below a trivial comparison.
-        /// let key_bytes_padded = secret_key.unprotected_as_bytes();
+        /// let secret_key = SecretKey::generate();
+        /// 
+        /// // Get the byte slice out of the key to demonstrate the comparison.
+        /// let key_bytes = secret_key.unprotected_as_bytes();
         ///
         /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
-        /// assert!(secret_key.unprotected_as_bytes() == key_bytes_padded);
+        /// assert!(secret_key.unprotected_as_bytes() == key_bytes);
         ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
-        /// assert!(secret_key == key_bytes_padded);
+        /// assert!(secret_key == key_bytes);
         /// ```
         pub struct $name {
             value: [u8; $size],
@@ -765,12 +744,10 @@ macro_rules! construct_secret_key_variable_size {
         /// use orion::pwhash::Password;
         ///
         /// // Initialize a password with 32 random bytes.
-        /// let pw_bytes: [u8; 32] =
-        ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
-        ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
-        ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
-        ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
-        /// let password = Password::from_slice(&pw_bytes).unwrap();
+        /// let password = Password::generate(32).unwrap();
+
+        /// // Get the byte slice out of the Password to demonstrate the comparison.
+        /// let pw_bytes = password.unprotected_as_bytes();
         ///
         /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
         /// assert!(password.unprotected_as_bytes() == pw_bytes);

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -564,6 +564,7 @@ macro_rules! construct_tag {
         ///
         /// // Secure, costant-time comparison with byte slice
         /// assert!(tag == &[1; 64][..]);
+        /// # Ok(())
         /// # }
         /// ```
         pub struct $name {

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -562,7 +562,7 @@ macro_rules! construct_tag {
         /// // Initialize an arbitrary, 64-byte tag.
         /// let tag = Tag::from_slice(&[1; 64])?;
         ///
-        /// // Constant-time comparison
+        /// // Secure, costant-time comparison with byte slice
         /// assert!(tag == &[1; 64][..]);
         /// # }
         /// ```

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -556,12 +556,15 @@ macro_rules! construct_tag {
         /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
         /// use orion::hazardous::mac::hmac::Tag;
+        /// # use orion::errors::UnknownCryptoError;
         ///
+        /// # fn main() -> Result<(), Box<UnknownCryptoError>> {
         /// // Initialize an arbitrary, 64-byte tag.
-        /// let tag = Tag::from_slice(&[1; 64]).unwrap();
+        /// let tag = Tag::from_slice(&[1; 64])?;
         ///
         /// // Constant-time comparison
         /// assert!(tag == &[1; 64][..]);
+        /// # }
         /// ```
         pub struct $name {
             value: [u8; $upper_bound],
@@ -730,12 +733,17 @@ macro_rules! construct_secret_key_variable_size {
         /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
         /// use orion::pwhash::Password;
+        /// # use orion::errors::UnknownCryptoError;
         ///
+        /// # fn main() -> Result<(), Box<UnknownCryptoError>> {
         /// // Initialize a password with 32 random bytes.
-        /// let password = Password::generate(32).unwrap();
+        /// let password = Password::generate(32)?;
         ///
         /// // Secure, costant-time comparison with byte slice
         /// assert!(password != &[0; 32][..]);
+        /// #
+        /// # Ok(())
+        /// # }
         /// ```
         pub struct $name {
             value: Vec<u8>,

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -395,6 +395,30 @@ macro_rules! construct_secret_key {
         /// # Security:
         /// - __**Avoid using**__ `unprotected_as_bytes()` whenever possible, as it breaks all protections
         /// that the type implements.
+        ///
+        /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// is implemented in such a way that the comparison happens in constant time. Thus, users should
+        /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
+        /// Examples are shown below. Although the `orion::hazardous::stream::chacha20::SecretKey`
+        /// type is used, this example applies to any fixed-size store of sensitive data.
+        /// ```rust
+        /// use orion::hazardous::stream::chacha20::SecretKey;
+        ///
+        /// // Initialize a secret key with 32 random bytes.
+        /// let key_bytes: [u8; 32] = 
+        ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
+        ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
+        ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
+        ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
+        /// let secret_key = SecretKey::from_slice(&key_bytes).unwrap();
+        /// 
+        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
+        /// assert!(secret_key.unprotected_as_bytes() == key_bytes);
+        /// 
+        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
+        /// assert!(secret_key == &key_bytes[..]);
+        /// ```
         pub struct $name {
             value: [u8; $upper_bound],
             original_length: usize,
@@ -533,6 +557,33 @@ macro_rules! construct_tag {
         /// # Security:
         /// - __**Avoid using**__ `unprotected_as_bytes()` whenever possible, as it breaks all protections
         /// that the type implements.
+        ///
+        /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// is implemented in such a way that the comparison happens in constant time. Thus, users should
+        /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
+        /// Examples are shown below.
+        /// ```rust
+        /// use orion::hazardous::mac::hmac::Tag;
+        ///
+        /// // Initialize a tag with 64 random bytes.
+        /// let tag_bytes: [u8; 64] = 
+        ///     [0x15, 0xf2, 0x52, 0x22, 0x01, 0x4c, 0x01, 0x85,
+        ///      0x6d, 0xe3, 0xb4, 0x94, 0x09, 0x9a, 0xe8, 0x28, 
+        ///      0xf1, 0x61, 0xc8, 0xbc, 0x57, 0x2e, 0xa3, 0x1a,
+        ///      0x49, 0x1f, 0x79, 0x84, 0x93, 0x49, 0x68, 0xab,
+        ///      0xb2, 0xc8, 0xf1, 0xa7, 0xa6, 0xbc, 0x4d, 0x60,
+        ///      0x09, 0x91, 0x50, 0x22, 0xd5, 0xf9, 0xa1, 0x80,
+        ///      0x46, 0x25, 0x3c, 0x2e, 0x76, 0x79, 0xaa, 0xa1,
+        ///      0x84, 0x95, 0x70, 0x20, 0xf2, 0xfd, 0xe5, 0x16];
+        /// let tag = Tag::from_slice(&tag_bytes).unwrap();
+        ///
+        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
+        /// assert!(tag.unprotected_as_bytes() == &tag_bytes[..]);
+        /// 
+        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
+        /// assert!(tag == &tag_bytes[..]);
+        /// ```
         pub struct $name {
             value: [u8; $upper_bound],
             original_length: usize,
@@ -579,6 +630,34 @@ macro_rules! construct_hmac_key {
         /// # Security:
         /// - __**Avoid using**__ `unprotected_as_bytes()` whenever possible, as it breaks all protections
         /// that the type implements.
+        ///
+        /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// is implemented in such a way that the comparison happens in constant time. Thus, users should
+        /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
+        /// Examples are shown below.
+        /// ```rust
+        /// use orion::hazardous::mac::hmac::SecretKey;
+        ///
+        /// // Initialize a secret key with 32 random bytes.
+        /// let key_bytes: [u8; 32] = 
+        ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
+        ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
+        ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
+        ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
+        /// let secret_key = SecretKey::from_slice(&key_bytes).unwrap();
+        /// 
+        /// // The `SecretKey::from_slice` function pads the key,
+        /// // so we need to get a new slice for comparisons. Admittedly,
+        /// // this does make the insecure example below a trivial comparison.
+        /// let key_bytes_padded = secret_key.unprotected_as_bytes();
+        /// 
+        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
+        /// assert!(secret_key.unprotected_as_bytes() == key_bytes_padded);
+        /// 
+        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
+        /// assert!(secret_key == key_bytes_padded);
+        /// ```
         pub struct $name {
             value: [u8; $size],
             original_length: usize,
@@ -677,6 +756,30 @@ macro_rules! construct_secret_key_variable_size {
         /// # Security:
         /// - __**Avoid using**__ `unprotected_as_bytes()` whenever possible, as it breaks all protections
         /// that the type implements.
+        ///
+        /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// is implemented in such a way that the comparison happens in constant time. Thus, users should
+        /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
+        /// Examples are shown below. Although the `orion::pwhash::Password` type is used, this example
+        /// applies to any heap-allocated store of sensitive data.
+        /// ```rust
+        /// use orion::pwhash::Password;
+        ///
+        /// // Initialize a password with 32 random bytes.
+        /// let pw_bytes: [u8; 32] = 
+        ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
+        ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
+        ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
+        ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
+        /// let password = Password::from_slice(&pw_bytes).unwrap();
+        /// 
+        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
+        /// assert!(password.unprotected_as_bytes() == pw_bytes);
+        /// 
+        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
+        /// assert!(password == &pw_bytes[..]);
+        /// ```
         pub struct $name {
             value: Vec<u8>,
             original_length: usize,

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -400,8 +400,7 @@ macro_rules! construct_secret_key {
         /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
-        /// Examples are shown below. Although the `orion::hazardous::stream::chacha20::SecretKey`
-        /// type is used, this example applies to any fixed-size store of sensitive data.
+        /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
         /// use orion::hazardous::stream::chacha20::SecretKey;
         ///
@@ -562,7 +561,7 @@ macro_rules! construct_tag {
         /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
-        /// Examples are shown below.
+        /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
         /// use orion::hazardous::mac::hmac::Tag;
         ///
@@ -635,7 +634,7 @@ macro_rules! construct_hmac_key {
         /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
-        /// Examples are shown below.
+        /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
         /// use orion::hazardous::mac::hmac::SecretKey;
         ///
@@ -761,8 +760,7 @@ macro_rules! construct_secret_key_variable_size {
         /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
-        /// Examples are shown below. Although the `orion::pwhash::Password` type is used, this example
-        /// applies to any heap-allocated store of sensitive data.
+        /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
         /// use orion::pwhash::Password;
         ///

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -407,11 +407,8 @@ macro_rules! construct_secret_key {
         /// // Initialize a secret key with 32 random bytes.
         /// let secret_key = SecretKey::generate();
         ///
-        /// // Get the byte slice out of the key to demonstrate the comparison.
-        /// let key_bytes = secret_key.unprotected_as_bytes();
-        ///
         /// // Secure, costant-time comparison with byte slice
-        /// assert!(secret_key == &key_bytes[..]);
+        /// assert!(secret_key != &[0; 32][..]);
         /// ```
         pub struct $name {
             value: [u8; $upper_bound],
@@ -623,12 +620,9 @@ macro_rules! construct_hmac_key {
         ///
         /// // Initialize a secret key with 32 random bytes.
         /// let secret_key = SecretKey::generate();
-        /// 
-        /// // Get the byte slice out of the key to demonstrate the comparison.
-        /// let key_bytes = secret_key.unprotected_as_bytes();
         ///
         /// // Secure, costant-time comparison with byte slice
-        /// assert!(secret_key == key_bytes);
+        /// assert!(secret_key != key_bytes);
         /// ```
         pub struct $name {
             value: [u8; $size],
@@ -739,12 +733,9 @@ macro_rules! construct_secret_key_variable_size {
         ///
         /// // Initialize a password with 32 random bytes.
         /// let password = Password::generate(32).unwrap();
-
-        /// // Get the byte slice out of the Password to demonstrate the comparison.
-        /// let pw_bytes = password.unprotected_as_bytes();
         ///
         /// // Secure, costant-time comparison with byte slice
-        /// assert!(password == &pw_bytes[..]);
+        /// assert!(password != &[0; 32][..]);
         /// ```
         pub struct $name {
             value: Vec<u8>,

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -410,7 +410,7 @@ macro_rules! construct_secret_key {
         /// // Get the byte slice out of the key to demonstrate the comparison.
         /// let key_bytes = secret_key.unprotected_as_bytes();
         ///
-        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
+        /// // Secure, costant-time comparison with byte slice
         /// assert!(secret_key == &key_bytes[..]);
         /// ```
         pub struct $name {
@@ -627,7 +627,7 @@ macro_rules! construct_hmac_key {
         /// // Get the byte slice out of the key to demonstrate the comparison.
         /// let key_bytes = secret_key.unprotected_as_bytes();
         ///
-        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
+        /// // Secure, costant-time comparison with byte slice
         /// assert!(secret_key == key_bytes);
         /// ```
         pub struct $name {
@@ -743,7 +743,7 @@ macro_rules! construct_secret_key_variable_size {
         /// // Get the byte slice out of the Password to demonstrate the comparison.
         /// let pw_bytes = password.unprotected_as_bytes();
         ///
-        /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
+        /// // Secure, costant-time comparison with byte slice
         /// assert!(password == &pw_bytes[..]);
         /// ```
         pub struct $name {

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -397,7 +397,7 @@ macro_rules! construct_secret_key {
         /// that the type implements.
         ///
         /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
-        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below. Although the `orion::hazardous::stream::chacha20::SecretKey`
@@ -559,7 +559,7 @@ macro_rules! construct_tag {
         /// that the type implements.
         ///
         /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
-        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below.
@@ -632,7 +632,7 @@ macro_rules! construct_hmac_key {
         /// that the type implements.
         ///
         /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
-        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below.
@@ -758,7 +758,7 @@ macro_rules! construct_secret_key_variable_size {
         /// that the type implements.
         ///
         /// - The trait `PartialEq<&'_ [u8]>` is implemented for this type so that users are not tempted
-        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte string. The trait
+        /// to call `unprotected_as_bytes` to compare this sensitive value to a byte slice. The trait
         /// is implemented in such a way that the comparison happens in constant time. Thus, users should
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below. Although the `orion::pwhash::Password` type is used, this example

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -410,9 +410,6 @@ macro_rules! construct_secret_key {
         /// // Get the byte slice out of the key to demonstrate the comparison.
         /// let key_bytes = secret_key.unprotected_as_bytes();
         ///
-        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
-        /// assert!(secret_key.unprotected_as_bytes() == key_bytes);
-        ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
         /// assert!(secret_key == &key_bytes[..]);
         /// ```
@@ -630,9 +627,6 @@ macro_rules! construct_hmac_key {
         /// // Get the byte slice out of the key to demonstrate the comparison.
         /// let key_bytes = secret_key.unprotected_as_bytes();
         ///
-        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
-        /// assert!(secret_key.unprotected_as_bytes() == key_bytes);
-        ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
         /// assert!(secret_key == key_bytes);
         /// ```
@@ -748,9 +742,6 @@ macro_rules! construct_secret_key_variable_size {
 
         /// // Get the byte slice out of the Password to demonstrate the comparison.
         /// let pw_bytes = password.unprotected_as_bytes();
-        ///
-        /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
-        /// assert!(password.unprotected_as_bytes() == pw_bytes);
         ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
         /// assert!(password == &pw_bytes[..]);

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -406,16 +406,16 @@ macro_rules! construct_secret_key {
         /// use orion::hazardous::stream::chacha20::SecretKey;
         ///
         /// // Initialize a secret key with 32 random bytes.
-        /// let key_bytes: [u8; 32] = 
+        /// let key_bytes: [u8; 32] =
         ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
         ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
         ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
         ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
         /// let secret_key = SecretKey::from_slice(&key_bytes).unwrap();
-        /// 
+        ///
         /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
         /// assert!(secret_key.unprotected_as_bytes() == key_bytes);
-        /// 
+        ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
         /// assert!(secret_key == &key_bytes[..]);
         /// ```
@@ -567,9 +567,9 @@ macro_rules! construct_tag {
         /// use orion::hazardous::mac::hmac::Tag;
         ///
         /// // Initialize a tag with 64 random bytes.
-        /// let tag_bytes: [u8; 64] = 
+        /// let tag_bytes: [u8; 64] =
         ///     [0x15, 0xf2, 0x52, 0x22, 0x01, 0x4c, 0x01, 0x85,
-        ///      0x6d, 0xe3, 0xb4, 0x94, 0x09, 0x9a, 0xe8, 0x28, 
+        ///      0x6d, 0xe3, 0xb4, 0x94, 0x09, 0x9a, 0xe8, 0x28,
         ///      0xf1, 0x61, 0xc8, 0xbc, 0x57, 0x2e, 0xa3, 0x1a,
         ///      0x49, 0x1f, 0x79, 0x84, 0x93, 0x49, 0x68, 0xab,
         ///      0xb2, 0xc8, 0xf1, 0xa7, 0xa6, 0xbc, 0x4d, 0x60,
@@ -580,7 +580,7 @@ macro_rules! construct_tag {
         ///
         /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
         /// assert!(tag.unprotected_as_bytes() == &tag_bytes[..]);
-        /// 
+        ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
         /// assert!(tag == &tag_bytes[..]);
         /// ```
@@ -640,21 +640,21 @@ macro_rules! construct_hmac_key {
         /// use orion::hazardous::mac::hmac::SecretKey;
         ///
         /// // Initialize a secret key with 32 random bytes.
-        /// let key_bytes: [u8; 32] = 
+        /// let key_bytes: [u8; 32] =
         ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
         ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
         ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
         ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
         /// let secret_key = SecretKey::from_slice(&key_bytes).unwrap();
-        /// 
+        ///
         /// // The `SecretKey::from_slice` function pads the key,
         /// // so we need to get a new slice for comparisons. Admittedly,
         /// // this does make the insecure example below a trivial comparison.
         /// let key_bytes_padded = secret_key.unprotected_as_bytes();
-        /// 
+        ///
         /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
         /// assert!(secret_key.unprotected_as_bytes() == key_bytes_padded);
-        /// 
+        ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
         /// assert!(secret_key == key_bytes_padded);
         /// ```
@@ -767,16 +767,16 @@ macro_rules! construct_secret_key_variable_size {
         /// use orion::pwhash::Password;
         ///
         /// // Initialize a password with 32 random bytes.
-        /// let pw_bytes: [u8; 32] = 
+        /// let pw_bytes: [u8; 32] =
         ///     [0x2f, 0xbd, 0x03, 0xeb, 0x36, 0x66, 0xa9, 0x8c,
         ///      0x39, 0x7f, 0xe7, 0xc3, 0x53, 0x4b, 0x9f, 0x8e,
         ///      0x17, 0x76, 0x5d, 0x96, 0xf4, 0x08, 0x6c, 0x8f,
         ///      0x25, 0x98, 0x80, 0xd9, 0xb2, 0xa5, 0x56, 0xce];
         /// let password = Password::from_slice(&pw_bytes).unwrap();
-        /// 
+        ///
         /// // Variable-time comparison: INSECURE!! DO NOT DO THIS!!
         /// assert!(password.unprotected_as_bytes() == pw_bytes);
-        /// 
+        ///
         /// // Constant-time comparison: SECURE, PREFER THIS WHEN POSSIBLE
         /// assert!(password == &pw_bytes[..]);
         /// ```


### PR DESCRIPTION
One unresolved issue is having independent documentation generated for each type that a single macro creates. I'm not currently sure how to solve this.