### PR TITLE
Vectorize ChaCha20

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -73,8 +73,7 @@ pub fn authenticate(secret_key: &SecretKey, data: &[u8]) -> Result<Tag, UnknownC
 		secret_key.unprotected_as_bytes(),
 	)?);
 	state.update(data)?;
-
-	Ok(state.finalize()?)
+	state.finalize()
 }
 
 #[must_use]
@@ -85,10 +84,7 @@ pub fn authenticate_verify(
 	data: &[u8],
 ) -> Result<bool, UnknownCryptoError> {
 	let key = hmac::SecretKey::from_slice(secret_key.unprotected_as_bytes())?;
-
-	hmac::verify(expected, &key, data)?;
-
-	Ok(true)
+	hmac::verify(expected, &key, data)
 }
 
 // Testing public functions in the module.

--- a/src/endianness.rs
+++ b/src/endianness.rs
@@ -43,7 +43,6 @@ macro_rules! impl_store_into {
 macro_rules! impl_load_into {
 	($type_alias:ty, $type_alias_expr:ident, $conv_function:ident, $func_name:ident) => {
 		#[inline]
-		#[allow(dead_code)]
 		/// Load bytes in `src` into `dst`.
 		pub fn $func_name(src: &[u8], dst: &mut [$type_alias]) {
 			let type_alias_len = mem::size_of::<$type_alias>();
@@ -76,6 +75,7 @@ macro_rules! impl_load {
 
 impl_load!(u32, u32, from_le_bytes, load_u32_le);
 
+#[cfg(test)]
 impl_load_into!(u32, u32, from_le_bytes, load_u32_into_le);
 
 impl_load_into!(u64, u64, from_le_bytes, load_u64_into_le);

--- a/src/endianness.rs
+++ b/src/endianness.rs
@@ -43,6 +43,7 @@ macro_rules! impl_store_into {
 macro_rules! impl_load_into {
 	($type_alias:ty, $type_alias_expr:ident, $conv_function:ident, $func_name:ident) => {
 		#[inline]
+		#[allow(dead_code)]
 		/// Load bytes in `src` into `dst`.
 		pub fn $func_name(src: &[u8], dst: &mut [$type_alias]) {
 			let type_alias_len = mem::size_of::<$type_alias>();

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -61,7 +61,7 @@ use crate::{errors::UnknownCryptoError, hazardous::hash::blake2b};
 #[must_use]
 /// Hashing using BLAKE2b-256.
 pub fn digest(data: &[u8]) -> Result<Digest, UnknownCryptoError> {
-	Ok(blake2b::Hasher::Blake2b256.digest(data)?)
+	blake2b::Hasher::Blake2b256.digest(data)
 }
 
 // Testing public functions in the module.

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -196,7 +196,7 @@ pub fn seal(
 	}
 
 	let optional_ad = match ad {
-		Some(ref n_val) => *n_val,
+		Some(n_val) => n_val,
 		None => &[0u8; 0],
 	};
 
@@ -210,7 +210,7 @@ pub fn seal(
 	)?;
 	let mut poly1305_state = poly1305::init(&poly1305_key);
 
-	process_authentication(&mut poly1305_state, &optional_ad, &dst_out, plaintext.len())?;
+	process_authentication(&mut poly1305_state, optional_ad, &dst_out, plaintext.len())?;
 	dst_out[plaintext.len()..(plaintext.len() + POLY1305_OUTSIZE)]
 		.copy_from_slice(&poly1305_state.finalize()?.unprotected_as_bytes());
 
@@ -234,7 +234,7 @@ pub fn open(
 	}
 
 	let optional_ad = match ad {
-		Some(ref n_val) => *n_val,
+		Some(n_val) => n_val,
 		None => &[0u8; 0],
 	};
 
@@ -244,7 +244,7 @@ pub fn open(
 	let mut poly1305_state = poly1305::init(&poly1305_key);
 	process_authentication(
 		&mut poly1305_state,
-		&optional_ad,
+		optional_ad,
 		ciphertext_with_tag,
 		ciphertext_len,
 	)?;

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -120,9 +120,7 @@ pub fn seal(
 		plaintext,
 		ad,
 		dst_out,
-	)?;
-
-	Ok(())
+	)
 }
 
 #[must_use]
@@ -145,9 +143,7 @@ pub fn open(
 		ciphertext_with_tag,
 		ad,
 		dst_out,
-	)?;
-
-	Ok(())
+	)
 }
 
 //

--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -670,7 +670,7 @@ mod public {
 				/// Given some data, .digest() should produce the same output as when
 				/// calling with streaming state.
 				fn prop_hasher_digest_256_same_as_streaming(data: Vec<u8>) -> bool {
-					let d256 = Hasher::Blake2b256.digest(&data[..]).unwrap();;
+					let d256 = Hasher::Blake2b256.digest(&data[..]).unwrap();
 
 					let mut state = init(None, 32).unwrap();
 					state.update(&data[..]).unwrap();
@@ -683,7 +683,7 @@ mod public {
 				/// Given some data, .digest() should produce the same output as when
 				/// calling with streaming state.
 				fn prop_hasher_digest_384_same_as_streaming(data: Vec<u8>) -> bool {
-					let d256 = Hasher::Blake2b384.digest(&data[..]).unwrap();;
+					let d256 = Hasher::Blake2b384.digest(&data[..]).unwrap();
 
 					let mut state = init(None, 48).unwrap();
 					state.update(&data[..]).unwrap();
@@ -696,7 +696,7 @@ mod public {
 				/// Given some data, .digest() should produce the same output as when
 				/// calling with streaming state.
 				fn prop_hasher_digest_512_same_as_streaming(data: Vec<u8>) -> bool {
-					let d256 = Hasher::Blake2b512.digest(&data[..]).unwrap();;
+					let d256 = Hasher::Blake2b512.digest(&data[..]).unwrap();
 
 					let mut state = init(None, 64).unwrap();
 					state.update(&data[..]).unwrap();

--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -417,7 +417,7 @@ impl Blake2b {
 		let mut digest = [0u8; 64];
 		store_u64_into_le(&self.internal_state, &mut digest);
 
-		Ok(Digest::from_slice(&digest[..self.size])?)
+		Digest::from_slice(&digest[..self.size])
 	}
 }
 

--- a/src/hazardous/hash/sha512.rs
+++ b/src/hazardous/hash/sha512.rs
@@ -406,8 +406,7 @@ pub fn init() -> Sha512 {
 pub fn digest(data: &[u8]) -> Result<Digest, UnknownCryptoError> {
 	let mut state = init();
 	state.update(data)?;
-
-	Ok(state.finalize()?)
+	state.finalize()
 }
 
 #[cfg(test)]

--- a/src/hazardous/kdf/hkdf.rs
+++ b/src/hazardous/kdf/hkdf.rs
@@ -80,8 +80,7 @@ use crate::{
 pub fn extract(salt: &[u8], ikm: &[u8]) -> Result<hmac::Tag, UnknownCryptoError> {
 	let mut prk = hmac::init(&SecretKey::from_slice(salt)?);
 	prk.update(ikm)?;
-
-	Ok(prk.finalize()?)
+	prk.finalize()
 }
 
 #[must_use]
@@ -133,9 +132,7 @@ pub fn derive_key(
 	info: Option<&[u8]>,
 	dst_out: &mut [u8],
 ) -> Result<(), UnknownCryptoError> {
-	expand(&extract(salt, ikm)?, info, dst_out)?;
-
-	Ok(())
+	expand(&extract(salt, ikm)?, info, dst_out)
 }
 
 #[must_use]

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -150,8 +150,7 @@ impl Hmac {
 		if self.is_finalized {
 			Err(UnknownCryptoError)
 		} else {
-			self.working_hasher.update(data)?;
-			Ok(())
+			self.working_hasher.update(data)
 		}
 	}
 
@@ -190,8 +189,7 @@ pub fn init(secret_key: &SecretKey) -> Hmac {
 pub fn hmac(secret_key: &SecretKey, data: &[u8]) -> Result<Tag, UnknownCryptoError> {
 	let mut hmac_state = init(secret_key);
 	hmac_state.update(data)?;
-
-	Ok(hmac_state.finalize()?)
+	hmac_state.finalize()
 }
 
 #[must_use]

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -421,8 +421,7 @@ pub fn init(one_time_key: &OneTimeKey) -> Poly1305 {
 pub fn poly1305(one_time_key: &OneTimeKey, data: &[u8]) -> Result<Tag, UnknownCryptoError> {
 	let mut poly_1305_state = init(one_time_key);
 	poly_1305_state.update(data)?;
-
-	Ok(poly_1305_state.finalize()?)
+	poly_1305_state.finalize()
 }
 
 #[must_use]

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -101,8 +101,8 @@
 //! [`SecretKey::generate()`]: https://docs.rs/orion/latest/orion/hazardous/stream/chacha20/struct.SecretKey.html
 //! [`aead`]: https://docs.rs/orion/latest/orion/hazardous/aead/index.html
 //! [XChaCha20Poly1305]: https://docs.rs/orion/latest/orion/hazardous/aead/xchacha20poly1305/index.html
+use crate::endianness::load_u32_le;
 use crate::errors::UnknownCryptoError;
-use core::convert::TryInto;
 use zeroize::Zeroize;
 
 /// The key size for ChaCha20.
@@ -261,31 +261,31 @@ impl InternalState {
 
 		// Row 1 and 2 with secret key.
 		let r1 = U32x4(
-			u32::from_le_bytes(sk[0..4].try_into().unwrap()),
-			u32::from_le_bytes(sk[4..8].try_into().unwrap()),
-			u32::from_le_bytes(sk[8..12].try_into().unwrap()),
-			u32::from_le_bytes(sk[12..16].try_into().unwrap()),
+			load_u32_le(&sk[0..4]),
+			load_u32_le(&sk[4..8]),
+			load_u32_le(&sk[8..12]),
+			load_u32_le(&sk[12..16]),
 		);
 
 		let r2 = U32x4(
-			u32::from_le_bytes(sk[16..20].try_into().unwrap()),
-			u32::from_le_bytes(sk[20..24].try_into().unwrap()),
-			u32::from_le_bytes(sk[24..28].try_into().unwrap()),
-			u32::from_le_bytes(sk[28..32].try_into().unwrap()),
+			load_u32_le(&sk[16..20]),
+			load_u32_le(&sk[20..24]),
+			load_u32_le(&sk[24..28]),
+			load_u32_le(&sk[28..32]),
 		);
 
 		let mut r3 = U32x4(0, 0, 0, 0);
 
 		if is_ietf {
 			// Counter is already set.
-			r3.1 = u32::from_le_bytes(n[0..4].try_into().unwrap());
-			r3.2 = u32::from_le_bytes(n[4..8].try_into().unwrap());
-			r3.3 = u32::from_le_bytes(n[8..12].try_into().unwrap());
+			r3.1 = load_u32_le(&n[0..4]);
+			r3.2 = load_u32_le(&n[4..8]);
+			r3.3 = load_u32_le(&n[8..12]);
 		} else {
-			r3.0 = u32::from_le_bytes(n[0..4].try_into().unwrap());
-			r3.1 = u32::from_le_bytes(n[4..8].try_into().unwrap());
-			r3.2 = u32::from_le_bytes(n[8..12].try_into().unwrap());
-			r3.3 = u32::from_le_bytes(n[12..16].try_into().unwrap());
+			r3.0 = load_u32_le(&n[0..4]);
+			r3.1 = load_u32_le(&n[4..8]);
+			r3.2 = load_u32_le(&n[8..12]);
+			r3.3 = load_u32_le(&n[12..16]);
 		}
 
 		Ok(Self {

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -28,7 +28,6 @@
 //! - `plaintext`: The data to be encrypted.
 //! - `dst_out`: Destination array that will hold the ciphertext/plaintext after
 //!   encryption/decryption.
-//! - `bytes`: The bytes that will be encrypted/decrypted when using the in-place functions.
 //!
 //! `nonce`: "Counters and LFSRs are both acceptable ways of generating unique
 //! nonces, as is encrypting a counter using a block cipher with a 64-bit block
@@ -40,7 +39,7 @@
 //! # Errors:
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` or `ciphertext`.
-//! - `plaintext`, `bytes` or `ciphertext` are empty.
+//! - `plaintext` or `ciphertext` are empty.
 //! - The `initial_counter` is high enough to cause a potential overflow.
 //!
 //! Even though `dst_out` is allowed to be of greater length than `plaintext`,
@@ -389,7 +388,7 @@ impl Serialize {
 
 #[must_use]
 /// In-place IETF ChaCha20 encryption as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
-pub fn encrypt_in_place(
+fn encrypt_in_place(
 	secret_key: &SecretKey,
 	nonce: &Nonce,
 	initial_counter: u32,
@@ -449,17 +448,6 @@ pub fn encrypt(
 		initial_counter,
 		&mut dst_out[..plaintext.len()],
 	)
-}
-
-#[must_use]
-/// In-place IETF ChaCha20 decryption as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
-pub fn decrypt_in_place(
-	secret_key: &SecretKey,
-	nonce: &Nonce,
-	initial_counter: u32,
-	bytes: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-	encrypt_in_place(secret_key, nonce, initial_counter, bytes)
 }
 
 #[must_use]

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -28,6 +28,7 @@
 //! - `plaintext`: The data to be encrypted.
 //! - `dst_out`: Destination array that will hold the ciphertext/plaintext after
 //!   encryption/decryption.
+//! - `bytes`: The bytes that will be encrypted/decrypted when using the in-place functions.
 //!
 //! `nonce`: "Counters and LFSRs are both acceptable ways of generating unique
 //! nonces, as is encrypting a counter using a block cipher with a 64-bit block
@@ -39,7 +40,7 @@
 //! # Errors:
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` or `ciphertext`.
-//! - `plaintext` or `ciphertext` are empty.
+//! - `plaintext`, `bytes` or `ciphertext` are empty.
 //! - The `initial_counter` is high enough to cause a potential overflow.
 //!
 //! Even though `dst_out` is allowed to be of greater length than `plaintext`,
@@ -247,9 +248,7 @@ impl InternalState {
 	/// Initialize either a ChaCha or HChaCha state with a `secret_key` and
 	/// `nonce`.
 	fn new(sk: &[u8], n: &[u8], is_ietf: bool) -> Result<Self, UnknownCryptoError> {
-		if sk.len() != CHACHA_KEYSIZE {
-			return Err(UnknownCryptoError);
-		}
+		debug_assert!(sk.len() == CHACHA_KEYSIZE);
 		if (n.len() != IETF_CHACHA_NONCESIZE) && is_ietf {
 			return Err(UnknownCryptoError);
 		}

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -274,7 +274,7 @@ impl InternalState {
 			u32::from_le_bytes(sk[28..32].try_into().unwrap()),
 		);
 
-		let mut r3 = U32x4(0u32.to_le(), 0, 0, 0);
+		let mut r3 = U32x4(0, 0, 0, 0);
 
 		if is_ietf {
 			// Counter is already set.
@@ -304,7 +304,7 @@ impl InternalState {
 	) -> Result<[U32x4; 4], UnknownCryptoError> {
 		if self.is_ietf {
 			match block_counter {
-				Some(counter) => self.state[3].0 = counter.to_le(),
+				Some(counter) => self.state[3].0 = counter,
 				None => return Err(UnknownCryptoError),
 			};
 		}

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -126,9 +126,7 @@ pub fn encrypt(
 		initial_counter,
 		plaintext,
 		dst_out,
-	)?;
-
-	Ok(())
+	)
 }
 
 #[must_use]
@@ -140,9 +138,7 @@ pub fn decrypt(
 	ciphertext: &[u8],
 	dst_out: &mut [u8],
 ) -> Result<(), UnknownCryptoError> {
-	encrypt(secret_key, nonce, initial_counter, ciphertext, dst_out)?;
-
-	Ok(())
+	encrypt(secret_key, nonce, initial_counter, ciphertext, dst_out)
 }
 
 //


### PR DESCRIPTION
This changes the internal ChaCha20 implementation to resemble a SIMD vectorization. The `encrypt`/`decrypt` functions now also make use of in-place xoring with the keystream internally.

