### PR TITLE
Remove "no_std" + "nightly" features and support no_std on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
       rust: stable
       install:
         - cargo install xargo || true
-        - rustup target install armv7-unknown-linux-gnueabihf
+        - rustup target add $TARGET
         - rustup component add rust-src
       script:
         # Debug:
@@ -90,12 +90,13 @@ matrix:
           
         # Release:
         - xargo build --release --no-default-features --verbose --target $TARGET
+
     - name: "[RELEASE + DEBUG (nightly)]: Build no_std"
       env: TARGET=thumbv7em-none-eabi
       rust: nightly
       install:
         - cargo install xargo || true
-        - rustup target install armv7-unknown-linux-gnueabihf
+        - rustup target add $TARGET
         - rustup component add rust-src
       script:
         # Debug:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ matrix:
         # No default features
         - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --tests --target x86_64-unknown-linux-gnu
         - RUSTFLAGS="-Z sanitizer=leak" cargo test --no-default-features --tests --target x86_64-unknown-linux-gnu
-        # Nightly features
-        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --features nightly --tests --target x86_64-unknown-linux-gnu
-        - RUSTFLAGS="-Z sanitizer=leak" cargo test --no-default-features --features nightly --tests --target x86_64-unknown-linux-gnu
         
         # Release:
         # Sanitizers with default features
@@ -39,9 +36,6 @@ matrix:
         # No default features
         - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --tests --release --target x86_64-unknown-linux-gnu
         - RUSTFLAGS="-Z sanitizer=leak" cargo test --no-default-features --tests --release --target x86_64-unknown-linux-gnu
-        # Nightly features
-        - RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS="detect_odr_violation=0" cargo test --no-default-features --features nightly --tests --release --target x86_64-unknown-linux-gnu
-        - RUSTFLAGS="-Z sanitizer=leak" cargo test --no-default-features --features nightly --tests --release --target x86_64-unknown-linux-gnu
 
         - cargo clean
 
@@ -51,12 +45,10 @@ matrix:
         # Debug:
         - cargo test
         - cargo test --no-default-features --tests
-        - cargo test --no-default-features --features nightly
         
         # Release:
         - cargo test --release
         - cargo test --release --no-default-features --tests
-        - cargo test --release --no-default-features --features nightly
 
     - name: "[RELEASE + DEBUG]: Tests + cargo-audit + clippy + fmt"
       rust: stable
@@ -85,7 +77,20 @@ matrix:
         - cargo test --release
         - cargo test --release --no-default-features --tests
 
-    - name: "[RELEASE + DEBUG]: Build no_std"
+    - name: "[RELEASE + DEBUG (stable)]: Build no_std"
+      env: TARGET=thumbv7em-none-eabi
+      rust: stable
+      install:
+        - cargo install xargo || true
+        - rustup target install armv7-unknown-linux-gnueabihf
+        - rustup component add rust-src
+      script:
+        # Debug:
+        - xargo build --no-default-features --verbose --target $TARGET
+          
+        # Release:
+        - xargo build --release --no-default-features --verbose --target $TARGET
+    - name: "[RELEASE + DEBUG (nightly)]: Build no_std"
       env: TARGET=thumbv7em-none-eabi
       rust: nightly
       install:
@@ -94,10 +99,10 @@ matrix:
         - rustup component add rust-src
       script:
         # Debug:
-        - xargo build --no-default-features --features no_std --verbose --target $TARGET
+        - xargo build --no-default-features --verbose --target $TARGET
           
         # Release:
-        - xargo build --release --no-default-features --features no_std --verbose --target $TARGET
+        - xargo build --release --no-default-features --verbose --target $TARGET
     
     - name: "[RELEASE + DEBUG]: 32-bit architecture"
       env: TARGET=i686-unknown-linux-gnu
@@ -143,7 +148,7 @@ matrix:
         - rustup target add wasm32-unknown-unknown
       script:
         # Release:
-        - cargo check --target wasm32-unknown-unknown
+        - cargo check --no-default-features --target wasm32-unknown-unknown
 
     - name: "[RELEASE (nightly)]: WebAssembly"
       env: TARGET=wasm32-unknown-unknown
@@ -152,7 +157,7 @@ matrix:
         - rustup target add wasm32-unknown-unknown
       script:
         # Release:
-        - cargo check --no-default-features --features no_std --target wasm32-unknown-unknown
+        - cargo check --no-default-features --target wasm32-unknown-unknown
     
     - name: "Documentation"
       rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,13 @@ exclude = [
 ]
 
 [dependencies]
-subtle = { version = "2.1.1", default-features = false }
+subtle = { version = "^2.2.1", default-features = false }
 zeroize = { version = "1.0.0", default-features = false }
 getrandom = { version = "0.1.12", optional = true }
 
 [features]
 default = [ "safe_api" ]
 safe_api = [ "getrandom" ]
-nightly = [ "subtle/nightly", "safe_api" ]
-no_std = [ "subtle/nightly" ]
 
 [dev-dependencies]
 hex = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ orion = { version = "*", default-features = false }
 # Replace * with the most recent version
 ```
 
-When orion is used in a `no_std` context, access to nearly all functionality, except for that in
-`hazardous`, is not available. This is because the high-level functionality depends on the systems random generator,
-which is not available in `no_std`.
+When orion is used in a `no_std` context, the high-level API is not available, since it relies on access to the systems random number generator.
 
 ### Documentation
 Can be viewed [here](https://docs.rs/orion) or built with:

--- a/README.md
+++ b/README.md
@@ -22,30 +22,18 @@ Rust 1.37 or later is supported however, the majority of testing happens with la
 
 MSRV may be changed at any point and will not be considered a SemVer breaking change.
 
-### Features
-- By default orion targets stable Rust and in this case, extra dependency specifications are not required.
+### Crate Features
+By default orion targets stable Rust and in this case, extra dependency specifications are not required.
 
-- `no_std`: To use orion in a `no_std` context, you need to specify the dependency as such:
+To use orion in a `no_std` context, you need to specify the dependency as such:
 ```
-[dependencies.orion]
-version = "*" # Replace * with the most recent version
-default-features = false
-features = ["no_std"]
+orion = { version = "*", default-features = false }
+# Replace * with the most recent version
 ```
-`no_std` requires Rust nightly and benefits from the same inline assembly features as when using the `nightly` feature.
 
 When orion is used in a `no_std` context, access to nearly all functionality, except for that in
 `hazardous`, is not available. This is because the high-level functionality depends on the systems random generator,
 which is not available in `no_std`.
-
-- `nightly`: The nightly feature enables the use of inline assembly for [constant-time comparisons](https://crates.io/crates/subtle). Using `nightly` is recommended for security. Specify the dependency as such, to use the `nightly` feature:
-```
-[dependencies.orion]
-version = "*" # Replace * with the most recent version
-default-features = false
-features = ["nightly"]
-```
-`nightly` requires Rust nightly.
 
 ### Documentation
 Can be viewed [here](https://docs.rs/orion) or built with:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,18 +21,15 @@ install:
   - cargo -V
 
 test_script:
-  - if [%RUST_VERSION%]==[stable] (
-      cargo build --target %TARGET% &&
-      cargo build --target %TARGET% --release &&
-      cargo test --target %TARGET% &&
-      cargo test --target %TARGET% --release
-    )
-  - if [%RUST_VERSION%]==[nightly]  (
-      cargo build --no-default-features --features nightly --target %TARGET% &&
-      cargo build --no-default-features --features nightly --target %TARGET% --release &&
-      cargo test --no-default-features --features nightly --target %TARGET% &&
-      cargo test --no-default-features --features nightly --target %TARGET% --release
-    )
+  - cargo build --target %TARGET%
+  - cargo build --target %TARGET% --release
+  - cargo test --target %TARGET%
+  - cargo test --target %TARGET% --release
+  # no_std
+  - cargo build --no-default-features --target %TARGET%
+  - cargo build --no-default-features --target %TARGET% --release
+  - cargo test --tests --no-default-features --target %TARGET%
+  - cargo test --tests --no-default-features --target %TARGET% --release
 
 cache:
   - C:\Users\appveyor\.cargo\registry


### PR DESCRIPTION
`subtle` has [added optimization barriers](https://github.com/dalek-cryptography/subtle/blob/master/CHANGELOG.md#221) on stable Rust, in version `2.2.1`. The reason we had a `nightly` feature before was to take advantage of these barriers, that were only available on nightly at the time.

This PR removes both `no_std` and `nightly` features in orion, making the crate-feature story a lot more simple. This enables using orion with `no_std` on both stable and nightly Rust (nightly is required for `no_std` now), only needing to specify `orion = { version = "*", default-features = false }`.