### PR TITLE
Vectorize BLAKE2b

### DIFF
--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -256,6 +256,7 @@ impl Blake2b {
 		let s_indexed = U64x4(m[s_idx[1]], m[s_idx[3]], m[s_idx[5]], m[s_idx[7]]);
 		Self::blake_qround(v, &s_indexed, 16, 63);
 
+		// Shuffle
 		v[1] = v[1].shl_1();
 		v[2] = v[2].shl_2();
 		v[3] = v[3].shl_3();
@@ -265,6 +266,7 @@ impl Blake2b {
 		let s_indexed = U64x4(m[s_idx[9]], m[s_idx[11]], m[s_idx[13]], m[s_idx[15]]);
 		Self::blake_qround(v, &s_indexed, 16, 63);
 
+		// Unshuffle
 		v[1] = v[1].shl_3();
 		v[2] = v[2].shl_2();
 		v[3] = v[3].shl_1();
@@ -281,9 +283,6 @@ impl Blake2b {
 			None => load_u64_into_le(&self.buffer, &mut m_vec),
 		}
 
-		let v0 = self.internal_state[0];
-		let v1 = self.internal_state[1];
-		let v2 = IV[0];
 		let v3 = U64x4(
 			self.t[0] ^ IV[1].0,
 			self.t[1] ^ IV[1].1,
@@ -291,7 +290,7 @@ impl Blake2b {
 			self.f[1] ^ IV[1].3,
 		);
 
-		let mut w_vec: [U64x4; 4] = [v0, v1, v2, v3];
+		let mut w_vec: [U64x4; 4] = [self.internal_state[0], self.internal_state[1], IV[0], v3];
 
 		Self::round(&SIGMA[0], &m_vec, &mut w_vec);
 		Self::round(&SIGMA[1], &m_vec, &mut w_vec);

--- a/src/util/endianness.rs
+++ b/src/util/endianness.rs
@@ -84,6 +84,7 @@ impl_load_into!(u64, u64, from_be_bytes, load_u64_into_be);
 
 impl_store_into!(u32, to_le_bytes, store_u32_into_le);
 
+#[cfg(test)]
 impl_store_into!(u64, to_le_bytes, store_u64_into_le);
 
 impl_store_into!(u64, to_be_bytes, store_u64_into_be);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -25,6 +25,7 @@ use subtle::ConstantTimeEq;
 
 pub(crate) mod endianness;
 pub(crate) mod u32x4;
+pub(crate) mod u64x4;
 
 #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
 #[cfg(feature = "safe_api")]

--- a/src/util/u64x4.rs
+++ b/src/util/u64x4.rs
@@ -1,0 +1,86 @@
+// MIT License
+
+// Copyright (c) 2018-2019 The orion Developers
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#[derive(Clone, Copy)]
+pub(crate) struct U64x4(
+	pub(crate) u64,
+	pub(crate) u64,
+	pub(crate) u64,
+	pub(crate) u64,
+);
+
+impl core::ops::BitXor for U64x4 {
+	type Output = Self;
+
+	#[must_use]
+	#[inline(always)]
+	fn bitxor(self, _rhs: Self) -> Self::Output {
+		Self(
+			self.0 ^ _rhs.0,
+			self.1 ^ _rhs.1,
+			self.2 ^ _rhs.2,
+			self.3 ^ _rhs.3,
+		)
+	}
+}
+
+impl U64x4 {
+	#[must_use]
+	#[inline(always)]
+	pub(crate) const fn wrapping_add(self, _rhs: Self) -> Self {
+		Self(
+			self.0.wrapping_add(_rhs.0),
+			self.1.wrapping_add(_rhs.1),
+			self.2.wrapping_add(_rhs.2),
+			self.3.wrapping_add(_rhs.3),
+		)
+	}
+
+	#[must_use]
+	#[inline(always)]
+	pub(crate) const fn shl_1(self) -> Self {
+		Self(self.1, self.2, self.3, self.0)
+	}
+
+	#[must_use]
+	#[inline(always)]
+	pub(crate) const fn shl_2(self) -> Self {
+		Self(self.2, self.3, self.0, self.1)
+	}
+
+	#[must_use]
+	#[inline(always)]
+	pub(crate) const fn shl_3(self) -> Self {
+		Self(self.3, self.0, self.1, self.2)
+	}
+
+	#[must_use]
+	#[inline(always)]
+	pub(crate) const fn rotate_right(self, n: u32) -> Self {
+		Self(
+			self.0.rotate_right(n),
+			self.1.rotate_right(n),
+			self.2.rotate_right(n),
+			self.3.rotate_right(n),
+		)
+	}
+}

--- a/src/util/u64x4.rs
+++ b/src/util/u64x4.rs
@@ -43,6 +43,30 @@ impl core::ops::BitXor for U64x4 {
 	}
 }
 
+impl core::ops::BitXorAssign for U64x4 {
+	#[must_use]
+	#[inline(always)]
+	fn bitxor_assign(&mut self, _rhs: Self) {
+		self.0 ^= _rhs.0;
+		self.1 ^= _rhs.1;
+		self.2 ^= _rhs.2;
+		self.3 ^= _rhs.3;
+	}
+}
+
+impl Default for U64x4 {
+	fn default() -> Self {
+		Self(0, 0, 0, 0)
+	}
+}
+
+#[cfg(test)]
+impl PartialEq<U64x4> for U64x4 {
+	fn eq(&self, other: &Self) -> bool {
+		(self.0 == other.0 && self.1 == other.1 && self.2 == other.2 && self.3 == other.3)
+	}
+}
+
 impl U64x4 {
 	#[must_use]
 	#[inline(always)]
@@ -82,5 +106,14 @@ impl U64x4 {
 			self.2.rotate_right(n),
 			self.3.rotate_right(n),
 		)
+	}
+
+	#[inline(always)]
+	pub(crate) fn store_into_le(self, dst: &mut [u8]) {
+		debug_assert!(dst.len() == core::mem::size_of::<u64>() * 4);
+		dst[0..8].copy_from_slice(&self.0.to_le_bytes());
+		dst[8..16].copy_from_slice(&self.1.to_le_bytes());
+		dst[16..24].copy_from_slice(&self.2.to_le_bytes());
+		dst[24..32].copy_from_slice(&self.3.to_le_bytes());
 	}
 }


### PR DESCRIPTION
This changes the internal BLAKE2b permutation to resemble SIMD vectorization (similar to how ChaCha20 [was vectorized](https://github.com/brycx/orion/pull/84)).

The approach to this vectorization has been taken from the [`blake2-rfc`](https://github.com/cesarb/blake2-rfc) crate.

This has shown the following increases in performance (measured on a Intel Core i7-4790K 4.0 GHz):

```
BLAKE2b-512/compute hash/512                                                                             
                        time:   [609.79 ns 610.74 ns 611.70 ns]
                        thrpt:  [798.24 MiB/s 799.50 MiB/s 800.73 MiB/s]
                 change:
                        time:   [-5.4893% -4.5062% -3.1013%] (p = 0.00 < 0.05)
                        thrpt:  [+3.2005% +4.7188% +5.8082%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe
BLAKE2b-512/compute hash/1024                                                                             
                        time:   [1.1434 us 1.1449 us 1.1465 us]
                        thrpt:  [851.77 MiB/s 852.97 MiB/s 854.12 MiB/s]
                 change:
                        time:   [-4.1132% -3.4438% -2.8255%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9077% +3.5666% +4.2896%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
BLAKE2b-512/compute hash/2048                                                                             
                        time:   [2.2060 us 2.2097 us 2.2136 us]
                        thrpt:  [882.32 MiB/s 883.87 MiB/s 885.36 MiB/s]
                 change:
                        time:   [-3.8288% -3.1037% -2.4512%] (p = 0.00 < 0.05)
                        thrpt:  [+2.5128% +3.2031% +3.9812%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
BLAKE2b-512/compute hash/4098                                                                             
                        time:   [4.5469 us 4.5549 us 4.5633 us]
                        thrpt:  [856.44 MiB/s 858.02 MiB/s 859.51 MiB/s]
                 change:
                        time:   [-3.6534% -3.0408% -2.4649%] (p = 0.00 < 0.05)
                        thrpt:  [+2.5272% +3.1362% +3.7919%]
```