### PR TITLE
aead: Use shared ChaCha20 state and remove keystream_block

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -66,6 +66,7 @@
 //! the security of all data that has been encrypted with that given key is
 //! compromised.
 //! - To securely generate a strong key, use [`SecretKey::default()`].
+//! - The length of `plaintext` is not hidden, only its contents.
 //!
 //! # Example:
 //! ```rust

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -23,8 +23,7 @@
 //! # Parameters:
 //! - `secret_key`: The secret key.
 //! - `nonce`: The nonce value.
-//! - `ad`: Additional data to authenticate (this is not encrypted and can be
-//!   `None`.  This data is also not a part of `dst_out`).
+//! - `ad`: Additional data to authenticate (this is not encrypted and can be `None`).
 //! - `ciphertext_with_tag`: The encrypted data with the corresponding 16 byte
 //!   Poly1305 tag appended to it.
 //! - `plaintext`: The data to be encrypted.
@@ -44,30 +43,29 @@
 //!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext + 16` when encrypting.
+//! - The length of `dst_out` is less than `plaintext + 16` when calling `seal()`.
 //! - The length of `dst_out` is less than `ciphertext_with_tag - 16` when
-//!   decrypting.
+//!   calling `open()`.
 //! - The length of `ciphertext_with_tag` is not greater than `16`.
-//! - `plaintext` or `ciphertext_with_tag` are empty.
-//! - The received tag does not match the calculated tag when decrypting.
-//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when encrypting.
+//! - `plaintext` is empty.
+//! - The received tag does not match the calculated tag when  calling `open()`.
+//! - `plaintext.len() + 16` overflows when  calling `seal()`.
 //! - Converting `usize` to `u64` would be a lossy conversion.
 //!
 //! # Panics:
 //! A panic will occur if:
-//! - More than 2^32-1 * 64 bytes of data are processed.
+//! - More than `2^32-1 * 64` bytes of data are processed.
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
-//!   key. Should this happen,
-//! the security of all data that has been encrypted with that given key is
-//! compromised.
+//!   key. Should this happen, the security of all data that has been encrypted
+//!   with that given key is compromised.
 //! - Only a nonce for XChaCha20Poly1305 is big enough to be randomly generated
 //!   using a CSPRNG.
 //! - To securely generate a strong key, use [`SecretKey::generate()`].
 //!
 //! # Recommendation:
-//! - It is recommended to use [XChaCha20Poly1305] when possible.
+//! - It is recommended to use [`XChaCha20Poly1305`] when possible.
 //!
 //! # Example:
 //! ```rust
@@ -75,9 +73,9 @@
 //!
 //! let secret_key = aead::chacha20poly1305::SecretKey::generate();
 //!
-//! let nonce = aead::chacha20poly1305::Nonce::from_slice(&[
-//!     0x07, 0x00, 0x00, 0x00, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
-//! ])?;
+//! // WARNING: This nonce is only meant for demonstration and should not
+//! // be repeated. Please read the security section.
+//! let nonce = aead::chacha20poly1305::Nonce::from([0u8; 12]);
 //! let ad = "Additional data".as_bytes();
 //! let message = "Data to protect".as_bytes();
 //!
@@ -95,7 +93,7 @@
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: ../../stream/chacha20/struct.SecretKey.html
-//! [XChaCha20Poly1305]: ../xchacha20poly1305/index.html
+//! [`XChaCha20Poly1305`]: ../xchacha20poly1305/index.html
 //! [`POLY1305_OUTSIZE`]: ../../mac/poly1305/constant.POLY1305_OUTSIZE.html
 pub use crate::hazardous::stream::chacha20::{Nonce, SecretKey};
 use crate::{

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -124,23 +124,6 @@ pub(crate) fn poly1305_key_gen(
     OneTimeKey::from_slice(&tmp_buffer[..POLY1305_KEYSIZE]).unwrap()
 }
 
-#[inline]
-/// Padding size that gives the needed bytes to pad `input` to an integral
-/// multiple of 16.
-pub(crate) fn padding(input: usize) -> usize {
-    if input == 0 {
-        return 0;
-    }
-
-    let rem = input % 16;
-
-    if rem != 0 {
-        16 - rem
-    } else {
-        0
-    }
-}
-
 /// Authenticates the ciphertext, ad and their lengths.
 fn process_authentication(
     auth_ctx: &mut Poly1305,
@@ -269,54 +252,6 @@ mod public {
 #[cfg(test)]
 mod private {
     use super::*;
-
-    mod test_padding {
-        use super::*;
-        #[test]
-        fn test_length_padding() {
-            assert_eq!(padding(0), 0);
-            assert_eq!(padding(1), 15);
-            assert_eq!(padding(2), 14);
-            assert_eq!(padding(3), 13);
-            assert_eq!(padding(4), 12);
-            assert_eq!(padding(5), 11);
-            assert_eq!(padding(6), 10);
-            assert_eq!(padding(7), 9);
-            assert_eq!(padding(8), 8);
-            assert_eq!(padding(9), 7);
-            assert_eq!(padding(10), 6);
-            assert_eq!(padding(11), 5);
-            assert_eq!(padding(12), 4);
-            assert_eq!(padding(13), 3);
-            assert_eq!(padding(14), 2);
-            assert_eq!(padding(15), 1);
-            assert_eq!(padding(16), 0);
-        }
-
-        // Proptests. Only executed when NOT testing no_std.
-        #[cfg(feature = "safe_api")]
-        mod proptest {
-            use super::*;
-
-            quickcheck! {
-                // The usize that padding() returns should always
-                // be what remains to make input a multiple of 16 in length.
-                fn prop_padding_result(input: usize) -> bool {
-                    let rem = padding(input);
-
-                    ((input + rem) % 16) == 0
-                }
-            }
-
-            quickcheck! {
-                // padding() should never return a usize above 15.
-                // The usize must always be in range of 0..=15.
-                fn prop_result_never_above_15(input: usize) -> bool {
-                    padding(input) < 16
-                }
-            }
-        }
-    }
 
     mod test_process_authentication {
         use super::*;

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -43,13 +43,13 @@
 //!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext + 16` when calling `seal()`.
-//! - The length of `dst_out` is less than `ciphertext_with_tag - 16` when
-//!   calling `open()`.
-//! - The length of `ciphertext_with_tag` is not greater than `16`.
+//! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`seal()`].
+//! - The length of `dst_out` is less than `ciphertext_with_tag` - [`POLY1305_OUTSIZE`] when
+//!   calling [`open()`].
+//! - The length of `ciphertext_with_tag` is not greater than [`POLY1305_OUTSIZE`].
 //! - `plaintext` is empty.
-//! - The received tag does not match the calculated tag when  calling `open()`.
-//! - `plaintext.len() + 16` overflows when  calling `seal()`.
+//! - The received tag does not match the calculated tag when  calling [`open()`].
+//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`seal()`].
 //! - Converting `usize` to `u64` would be a lossy conversion.
 //!
 //! # Panics:
@@ -63,6 +63,7 @@
 //! - Only a nonce for XChaCha20Poly1305 is big enough to be randomly generated
 //!   using a CSPRNG.
 //! - To securely generate a strong key, use [`SecretKey::generate()`].
+//! - The length of `plaintext` is not hidden, only its contents.
 //!
 //! # Recommendation:
 //! - It is recommended to use [`XChaCha20Poly1305`] when possible.
@@ -95,6 +96,8 @@
 //! [`SecretKey::generate()`]: ../../stream/chacha20/struct.SecretKey.html
 //! [`XChaCha20Poly1305`]: ../xchacha20poly1305/index.html
 //! [`POLY1305_OUTSIZE`]: ../../mac/poly1305/constant.POLY1305_OUTSIZE.html
+//! [`seal()`]: fn.seal.html
+//! [`open()`]: fn.open.html
 pub use crate::hazardous::stream::chacha20::{Nonce, SecretKey};
 use crate::{
     errors::UnknownCryptoError,

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -249,14 +249,15 @@ mod public {
     }
 }
 
+#[cfg(debug_assertions)]
 // Testing private functions in the module.
 #[cfg(test)]
 mod private {
     use super::*;
 
+    #[cfg(debug_assertions)]
     mod test_process_authentication {
         use super::*;
-
         #[test]
         #[should_panic]
         fn test_panic_empty_buf() {

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -51,7 +51,7 @@
 //! - `plaintext` or `ciphertext_with_tag` are empty.
 //! - The received tag does not match the calculated tag when decrypting.
 //! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when encrypting.
-//! - The length of
+//! - Converting `usize` to `u64` would be a lossy conversion.
 //!
 //! # Panics:
 //! A panic will occur if:

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -255,7 +255,6 @@ mod public {
 mod private {
     use super::*;
 
-    #[cfg(debug_assertions)]
     mod test_process_authentication {
         use super::*;
         #[test]

--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -215,10 +215,7 @@ impl StreamXChaCha20Poly1305 {
         let mut pad = [0u8; 16];
         let mut poly = Poly1305::new(&poly1305_key_gen(&mut chacha20_ctx, &mut tmp_block));
 
-        if !ad.is_empty() {
-            poly.update(ad)?;
-            poly.update(&pad[..padding(ad.len())])?;
-        }
+        poly.process_pad_to_blocksize(ad)?;
         poly.update(block)?;
         poly.update(&text[textpos..(textpos + msglen)])?;
         poly.update(&pad[..padding(CHACHA_BLOCKSIZE.wrapping_sub(msglen))])?;

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -45,6 +45,7 @@
 //! - `plaintext` or `ciphertext_with_tag` are empty.
 //! - The received tag does not match the calculated tag when decrypting.
 //! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when encrypting.
+//! - Converting `usize` to `u64` would be a lossy conversion.
 //!
 //! # Panics:
 //! A panic will occur if:

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -36,13 +36,13 @@
 //!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext + 16` when calling `seal()`.
-//! - The length of `dst_out` is less than `ciphertext_with_tag - 16` when
-//!   calling `open()`.
-//! - The length of `ciphertext_with_tag` is not greater than `16`.
+//! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`seal()`].
+//! - The length of `dst_out` is less than `ciphertext_with_tag` - [`POLY1305_OUTSIZE`] when
+//!   calling [`open()`].
+//! - The length of `ciphertext_with_tag` is not greater than [`POLY1305_OUTSIZE`].
 //! - `plaintext` is empty.
-//! - The received tag does not match the calculated tag when  calling `open()`.
-//! - `plaintext.len() + 16` overflows when  calling `seal()`.
+//! - The received tag does not match the calculated tag when  calling [`open()`].
+//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`seal()`].
 //! - Converting `usize` to `u64` would be a lossy conversion.
 //!
 //! # Panics:
@@ -56,6 +56,7 @@
 //! - Only a nonce for XChaCha20Poly1305 is big enough to be randomly generated
 //!   using a CSPRNG. [`Nonce::generate()`] can be used for this.
 //! - To securely generate a strong key, use [`SecretKey::generate()`].
+//! - The length of `plaintext` is not hidden, only its contents.
 //!
 //! # Recommendation:
 //! - It is recommended to use XChaCha20Poly1305 when possible.
@@ -85,6 +86,8 @@
 //! [`SecretKey::generate()`]: ../../stream/chacha20/struct.SecretKey.html
 //! [`Nonce::generate()`]: ../../stream/xchacha20/struct.Nonce.html
 //! [`POLY1305_OUTSIZE`]: ../../mac/poly1305/constant.POLY1305_OUTSIZE.html
+//! [`seal()`]: fn.seal.html
+//! [`open()`]: fn.open.html
 use crate::hazardous::stream::xchacha20::subkey_and_nonce;
 pub use crate::hazardous::stream::{chacha20::SecretKey, xchacha20::Nonce};
 use crate::{errors::UnknownCryptoError, hazardous::aead::chacha20poly1305};

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -23,11 +23,9 @@
 //! # Parameters:
 //! - `secret_key`: The secret key.
 //! - `nonce`: The nonce value.
-//! - `ad`: Additional data to authenticate (this is not encrypted and can be
-//!   `None`. This data is also not a part of `dst_out`).
+//! - `ad`: Additional data to authenticate (this is not encrypted and can be `None`).
 //! - `ciphertext_with_tag`: The encrypted data with the corresponding 16 byte
-//!   Poly1305 tag
-//! appended to it.
+//!   Poly1305 tag appended to it.
 //! - `plaintext`: The data to be encrypted.
 //! - `dst_out`: Destination array that will hold the
 //!   `ciphertext_with_tag`/`plaintext` after encryption/decryption.
@@ -38,27 +36,25 @@
 //!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext + 16` when encrypting.
+//! - The length of `dst_out` is less than `plaintext + 16` when calling `seal()`.
 //! - The length of `dst_out` is less than `ciphertext_with_tag - 16` when
-//!   decrypting.
+//!   calling `open()`.
 //! - The length of `ciphertext_with_tag` is not greater than `16`.
-//! - `plaintext` or `ciphertext_with_tag` are empty.
-//! - The received tag does not match the calculated tag when decrypting.
-//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when encrypting.
+//! - `plaintext` is empty.
+//! - The received tag does not match the calculated tag when  calling `open()`.
+//! - `plaintext.len() + 16` overflows when  calling `seal()`.
 //! - Converting `usize` to `u64` would be a lossy conversion.
 //!
 //! # Panics:
 //! A panic will occur if:
-//! - More than 2^32-1 * 64 bytes of data are processed.
+//! - More than `2^32-1 * 64` bytes of data are processed.
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
-//!   key. Should this happen,
-//! the security of all data that has been encrypted with that given key is
-//! compromised.
+//!   key. Should this happen, the security of all data that has been encrypted
+//!   with that given key is compromised.
 //! - Only a nonce for XChaCha20Poly1305 is big enough to be randomly generated
-//!   using a CSPRNG.
-//! [`Nonce::generate()`] can be used for this.
+//!   using a CSPRNG. [`Nonce::generate()`] can be used for this.
 //! - To securely generate a strong key, use [`SecretKey::generate()`].
 //!
 //! # Recommendation:
@@ -103,7 +99,6 @@ pub fn seal(
     dst_out: &mut [u8],
 ) -> Result<(), UnknownCryptoError> {
     let (subkey, ietf_nonce) = subkey_and_nonce(secret_key, nonce);
-
     chacha20poly1305::seal(&subkey, &ietf_nonce, plaintext, ad, dst_out)
 }
 
@@ -117,7 +112,6 @@ pub fn open(
     dst_out: &mut [u8],
 ) -> Result<(), UnknownCryptoError> {
     let (subkey, ietf_nonce) = subkey_and_nonce(secret_key, nonce);
-
     chacha20poly1305::open(&subkey, &ietf_nonce, ciphertext_with_tag, ad, dst_out)
 }
 

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -563,6 +563,33 @@ mod public {
 mod private {
     use super::*;
 
+    mod test_process_pad_to_blocksize {
+        use super::*;
+
+        #[test]
+        fn test_process_err_on_finalized() {
+            let sk = OneTimeKey::from_slice(&[0u8; 32]).unwrap();
+            let mut state = Poly1305::new(&sk);
+            
+            state.process_pad_to_blocksize(&[0u8; 16]).unwrap();
+            let _ = state.finalize().unwrap();
+            assert!(state.process_pad_to_blocksize(&[0u8; 16]).is_err());
+        }
+
+        #[test]
+        fn test_process_pad_no_pad() {
+            let sk = OneTimeKey::from_slice(&[0u8; 32]).unwrap();
+            let mut state_pad = Poly1305::new(&sk);
+            let mut state_no_pad = Poly1305::new(&sk);
+            
+            // 15 missing to be evenly divisible by 16.
+            state_pad.process_pad_to_blocksize(&[0u8; 17]).unwrap();
+            state_no_pad.process_pad_to_blocksize(&[0u8; 32]).unwrap();
+
+            assert_eq!(state_no_pad.finalize().unwrap(), state_pad.finalize().unwrap());
+        }
+    }
+
     mod test_process_block {
         use super::*;
 

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -570,7 +570,7 @@ mod private {
         fn test_process_err_on_finalized() {
             let sk = OneTimeKey::from_slice(&[0u8; 32]).unwrap();
             let mut state = Poly1305::new(&sk);
-            
+
             state.process_pad_to_blocksize(&[0u8; 16]).unwrap();
             let _ = state.finalize().unwrap();
             assert!(state.process_pad_to_blocksize(&[0u8; 16]).is_err());
@@ -581,12 +581,15 @@ mod private {
             let sk = OneTimeKey::from_slice(&[0u8; 32]).unwrap();
             let mut state_pad = Poly1305::new(&sk);
             let mut state_no_pad = Poly1305::new(&sk);
-            
+
             // 15 missing to be evenly divisible by 16.
             state_pad.process_pad_to_blocksize(&[0u8; 17]).unwrap();
             state_no_pad.process_pad_to_blocksize(&[0u8; 32]).unwrap();
 
-            assert_eq!(state_no_pad.finalize().unwrap(), state_pad.finalize().unwrap());
+            assert_eq!(
+                state_no_pad.finalize().unwrap(),
+                state_pad.finalize().unwrap()
+            );
         }
     }
 

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -48,30 +48,21 @@
 //!
 //! # Panics:
 //! A panic will occur if:
-//! - More than 2^32-1 keystream blocks are processed or more than 2^32-1 * 64
-//! bytes of data are processed.
-//!
-//! ### Note:
-//! [`keystream_block`] is for use-cases where more control over the keystream
-//! used for encryption/decryption is desired. It does not encrypt anything.
-//! This function's `counter` parameter is never increased and therefor is not
-//! checked for potential overflow on increase either. Only use it if you are
-//! absolutely sure you actually need to use it.
+//! - More than `2^32-1` keystream blocks are processed or more than `2^32-1 * 64`
+//!   bytes of data are processed.
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
-//!   key. Should this happen,
-//! the security of all data that has been encrypted with that given key is
-//! compromised.
+//!   key. Should this happen, the security of all data that has been encrypted
+//!   with that given key is compromised.
 //! - Functions herein do not provide any data integrity. If you need
-//! data integrity, which is nearly ***always the case***, you should use an
-//! AEAD construction instead. See orions [`aead`] module for this.
-//! - Only a nonce for XChaCha20 is big enough to be randomly generated using a
-//!   CSPRNG.
+//!   data integrity, which is nearly ***always the case***, you should use an
+//!   AEAD construction instead. See orions [`aead`] module for this.
+//! - Only a nonce for XChaCha20 is big enough to be randomly generated using a CSPRNG.
 //! - To securely generate a strong key, use [`SecretKey::generate()`].
 //!
 //! # Recommendation:
-//! - It is recommended to use [XChaCha20Poly1305] when possible.
+//! - It is recommended to use [`XChaCha20Poly1305`] when possible.
 //!
 //! # Example:
 //! ```rust
@@ -79,12 +70,12 @@
 //!
 //! let secret_key = chacha20::SecretKey::generate();
 //!
-//! let nonce = chacha20::Nonce::from_slice(&[
-//!     0x07, 0x00, 0x00, 0x00, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
-//! ])?;
-//!
-//! // Length of this message is 15
+//! // WARNING: This nonce is only meant for demonstration and should not
+//! // be repeated. Please read the security section.
+//! let nonce = chacha20::Nonce::from([0u8; 12]);
 //! let message = "Data to protect".as_bytes();
+//!
+//! // Length of this message is 15.
 //!
 //! let mut dst_out_pt = [0u8; 15];
 //! let mut dst_out_ct = [0u8; 15];
@@ -96,10 +87,9 @@
 //! assert_eq!(dst_out_pt, message);
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
-//! [`keystream_block`]: fn.keystream_block.html
 //! [`SecretKey::generate()`]: struct.SecretKey.html
 //! [`aead`]: ../../aead/index.html
-//! [XChaCha20Poly1305]: ../../aead/xchacha20poly1305/index.html
+//! [`XChaCha20Poly1305`]: ../../aead/xchacha20poly1305/index.html
 use crate::errors::UnknownCryptoError;
 use crate::util::endianness::load_u32_le;
 use crate::util::u32x4::U32x4;

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -392,7 +392,6 @@ mod public {
         use crate::test_framework::streamcipher_interface::*;
 
         // Proptests. Only executed when NOT testing no_std.
-        #[cfg(feature = "safe_api")]
         mod proptest {
             use super::*;
 
@@ -517,7 +516,6 @@ mod public {
     }
 
     // hex crate uses Vec<u8>, so we need std.
-    #[cfg(feature = "safe_api")]
     mod test_hchacha20 {
         use super::*;
 

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -41,23 +41,21 @@
 //!
 //! # Panics:
 //! A panic will occur if:
-//! - More than 2^32-1 * 64 bytes of data are processed.
+//! - More than `2^32-1 * 64` bytes of data are processed.
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
-//!   key. Should this happen,
-//! the security of all data that has been encrypted with that given key is
-//! compromised.
+//!   key. Should this happen, the security of all data that has been encrypted
+//!   with that given key is compromised.
 //! - Functions herein do not provide any data integrity. If you need
-//! data integrity, which is nearly ***always the case***, you should use an
-//! AEAD construction instead. See orions `aead` module for this.
+//!   data integrity, which is nearly ***always the case***, you should use an
+//!   AEAD construction instead. See orions [`aead`] module for this.
 //! - Only a nonce for XChaCha20 is big enough to be randomly generated using a
-//!   CSPRNG.
-//! [`Nonce::generate()`] can be used for this.
+//!   CSPRNG. [`Nonce::generate()`] can be used for this.
 //! - To securely generate a strong key, use [`SecretKey::generate()`].
 //!
 //! # Recommendation:
-//! - It is recommended to use [XChaCha20Poly1305] when possible.
+//! - It is recommended to use [`XChaCha20Poly1305`] when possible.
 //!
 //! # Example:
 //! ```rust
@@ -65,9 +63,9 @@
 //!
 //! let secret_key = xchacha20::SecretKey::generate();
 //! let nonce = xchacha20::Nonce::generate();
+//! let message = "Data to protect".as_bytes();
 //!
 //! // Length of this message is 15
-//! let message = "Data to protect".as_bytes();
 //!
 //! let mut dst_out_pt = [0u8; 15];
 //! let mut dst_out_ct = [0u8; 15];
@@ -81,7 +79,7 @@
 //! ```
 //! [`Nonce::generate()`]: struct.Nonce.html
 //! [`SecretKey::generate()`]: ../chacha20/struct.SecretKey.html
-//! [XChaCha20Poly1305]: ../../aead/xchacha20poly1305/index.html
+//! [`XChaCha20Poly1305`]: ../../aead/xchacha20poly1305/index.html
 pub use crate::hazardous::stream::chacha20::SecretKey;
 use crate::{
     errors::UnknownCryptoError,

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -394,12 +394,7 @@ pub fn hash_password(
         buffer.as_mut(),
     )?;
 
-    PasswordHash::from_slice(
-        buffer.as_ref(),
-        salt.as_ref(),
-        iterations,
-        memory,
-    )
+    PasswordHash::from_slice(buffer.as_ref(), salt.as_ref(), iterations, memory)
 }
 
 #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]


### PR DESCRIPTION
- Remove public `keystream_block` function. The same result can be achieved with all-0 input.
- Make `hazardous::aead::streaming::TAG_SIZE` constant public.
- Use a shared ChaCha20 state for encryption and authentication in `hazardous::aead`
- Have `hazardous::aead` return `Err()` if converting `usize` to `u64` would be a lossy conversion on the machine.