### PR TITLE
Add no_std support for Argon2i with alloc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,12 @@ jobs:
           command: test
           args: --no-default-features --tests
       
+      - name: Test debug-mode, alloc feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features alloc --tests
+      
       - name: Test release-mode, default features
         uses: actions-rs/cargo@v1
         with:
@@ -42,3 +48,9 @@ jobs:
         with:
           command: test
           args: --release --no-default-features --tests
+      
+      - name: Test release-mode, alloc feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features alloc --tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ base64 = { version = "0.12.0", optional = true }
 [features]
 default = [ "safe_api" ]
 safe_api = [ "getrandom", "base64" ]
+alloc = []
 
 [dev-dependencies]
 hex = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -23,12 +23,21 @@ MSRV may be changed at any point and will not be considered a SemVer breaking ch
 
 ### Crate Features
 By default orion targets stable Rust with `std`. To use orion in a `no_std` context, you need to specify the dependency as such:
-```
+```toml
 orion = { version = "*", default-features = false }
 # Replace * with the most recent version
 ```
 
-When orion is used in a `no_std` context, the high-level API is not available, since it relies on access to the systems random number generator.
+When orion is used in a `no_std` context, the high-level API is not available, since it relies on access to the systems random number generator. 
+
+Argon2i is not available with `no_std` by default, but can be by enabling the `alloc` feature:
+
+```toml
+[dependencies.orion]
+version = "*" # Replace * with the most recent version
+default-features = false
+features = ["alloc"]
+```
 
 ### Documentation
 Can be viewed [here](https://docs.rs/orion) or built with:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,11 @@ test_script:
   - cargo build --no-default-features --target %TARGET% --release
   - cargo test --tests --no-default-features --target %TARGET%
   - cargo test --tests --no-default-features --target %TARGET% --release
+  # alloc feature
+  - cargo build --no-default-features --features alloc --target %TARGET%
+  - cargo build --no-default-features --features alloc --target %TARGET% --release
+  - cargo test --tests --no-default-features --features alloc --target %TARGET%
+  - cargo test --tests --no-default-features --features alloc --target %TARGET% --release
 
 cache:
   - C:\Users\appveyor\.cargo\registry

--- a/src/hazardous/kdf/argon2i.rs
+++ b/src/hazardous/kdf/argon2i.rs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 //! # About:
-//! Argon2i version 1.3. This implementation is __not__ available with `no_std`.
+//! Argon2i version 1.3. This implementation is available with features `safe_api` and `alloc`.
 //!
 //! # Note:
 //! This implementation only supports a single thread/lane.

--- a/src/hazardous/kdf/argon2i.rs
+++ b/src/hazardous/kdf/argon2i.rs
@@ -543,11 +543,11 @@ pub fn verify(
 mod public {
     use super::*;
 
+    #[cfg(feature = "safe_api")]
     mod test_verify {
         use super::*;
 
         // Proptests. Only executed when NOT testing no_std.
-        #[cfg(feature = "safe_api")]
         mod proptest {
             use super::*;
 

--- a/src/hazardous/kdf/mod.rs
+++ b/src/hazardous/kdf/mod.rs
@@ -26,6 +26,6 @@ pub mod hkdf;
 /// PBKDF2-HMAC-SHA512 (Password-Based Key Derivation Function 2) as specified in the [RFC 8018](https://tools.ietf.org/html/rfc8018).
 pub mod pbkdf2;
 
-#[cfg(feature = "safe_api")]
+#[cfg(any(feature = "safe_api", feature = "alloc"))]
 /// Argon2i password hashing function as described in the [P-H-C specification](https://github.com/P-H-C/phc-winner-argon2/blob/master/argon2-specs.pdf).
 pub mod argon2i;

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -49,7 +49,7 @@
 //!   with that given key is compromised.
 //! - Functions herein do not provide any data integrity. If you need
 //!   data integrity, which is nearly ***always the case***, you should use an
-//!   AEAD construction instead. See orions [`aead`] module for this.
+//!   AEAD construction instead. See the [`aead`] module for this.
 //! - Only a nonce for XChaCha20 is big enough to be randomly generated using a
 //!   CSPRNG. [`Nonce::generate()`] can be used for this.
 //! - To securely generate a strong key, use [`SecretKey::generate()`].
@@ -80,6 +80,7 @@
 //! [`Nonce::generate()`]: struct.Nonce.html
 //! [`SecretKey::generate()`]: ../chacha20/struct.SecretKey.html
 //! [`XChaCha20Poly1305`]: ../../aead/xchacha20poly1305/index.html
+//! [`aead`]: ../../aead/index.html
 pub use crate::hazardous::stream::chacha20::SecretKey;
 use crate::{
     errors::UnknownCryptoError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,10 @@
 #[macro_use]
 extern crate quickcheck;
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(feature = "alloc", macro_use)]
+extern crate alloc;
+
 #[macro_use]
 mod typedefs;
 

--- a/src/util/endianness.rs
+++ b/src/util/endianness.rs
@@ -81,7 +81,7 @@ impl_load_into!(u64, u64, from_be_bytes, load_u64_into_be);
 
 impl_store_into!(u32, to_le_bytes, store_u32_into_le);
 
-#[cfg(any(feature = "safe_api", test))]
+#[cfg(any(feature = "safe_api", feature = "alloc", test))]
 impl_store_into!(u64, to_le_bytes, store_u64_into_le);
 
 impl_store_into!(u64, to_be_bytes, store_u64_into_be);


### PR DESCRIPTION
This enables using Argon2i in a `no_std` context, through the `alloc` crate. This is feature-gated with a "alloc" feature, to continue having heap allocations be opt-in.

Fixes #125.