### PR TITLE
Allow empty input when sealing with AEADs in hazardous

### DIFF
--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -415,11 +415,6 @@ mod public {
             ad: Option<&[u8]>,
             output: &mut [u8],
         ) -> Result<(), UnknownCryptoError> {
-            // NOTE: AeadTestRunner assumes that input must be at least
-            // 1. `seal_chunk` accepts 0 which is tested further down.
-            if input.len() == 0 {
-                return Err(UnknownCryptoError);
-            }
             let mut state = StreamXChaCha20Poly1305::new(sk, nonce);
             state.seal_chunk(input, ad, output, StreamTag::MESSAGE)
         }
@@ -431,12 +426,6 @@ mod public {
             ad: Option<&[u8]>,
             output: &mut [u8],
         ) -> Result<(), UnknownCryptoError> {
-            // NOTE: AeadTestRunner assumes that input must be at least
-            // ABYTES + 1. `open_chunk` accepts ABYTES exactly which is tested
-            // further down.
-            if input.len() == ABYTES {
-                return Err(UnknownCryptoError);
-            }
             let mut state = StreamXChaCha20Poly1305::new(sk, nonce);
             state.open_chunk(input, ad, output)?;
 

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -39,8 +39,7 @@
 //! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`seal()`].
 //! - The length of `dst_out` is less than `ciphertext_with_tag` - [`POLY1305_OUTSIZE`] when
 //!   calling [`open()`].
-//! - The length of the `ciphertext_with_tag` is not greater than [`POLY1305_OUTSIZE`].
-//! - The `plaintext` is empty.
+//! - The length of the `ciphertext_with_tag` is not at least [`POLY1305_OUTSIZE`].
 //! - The received tag does not match the calculated tag when  calling [`open()`].
 //! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`seal()`].
 //! - Converting `usize` to `u64` would be a lossy conversion.

--- a/tests/aead/mod.rs
+++ b/tests/aead/mod.rs
@@ -30,9 +30,6 @@ fn aead_test_runner(key: &[u8], nonce: &[u8], aad: &[u8], tag: &[u8], input: &[u
         assert!(SecretKey::from_slice(&key).is_err());
         return;
     }
-    if input.is_empty() || output.is_empty() {
-        return;
-    }
 
     let mut dst_ct_out = vec![0u8; input.len() + tag.len()];
     let mut dst_pt_out = vec![0u8; input.len()];
@@ -104,14 +101,6 @@ fn wycheproof_test_runner(
     tcid: u64,
     is_ietf: bool,
 ) -> Result<(), UnknownCryptoError> {
-    // Leave test vectors out that have empty input/output and are otherwise valid
-    // since orion does not accept this. This will be test cases with "tcId" = 2, 3.
-    if result {
-        if input.is_empty() && output.is_empty() {
-            return Ok(());
-        }
-    }
-
     let mut dst_ct_out = vec![0u8; input.len() + 16];
     let mut dst_pt_out = vec![0u8; input.len()];
 


### PR DESCRIPTION
This change allows empty input on AEADs sealing operation. The authentication tag is still calculated, using the optional AAD and is copied to the out parameters.


TODO:
- [X] Adjust fuzzing targets to allow empty inputs (See https://github.com/brycx/orion-fuzz/pull/8)
- [X] Figure out if empty input should be allowed in high-level API. If not, correct corresponding docs: I've found no use-case for this. Allowing empty input seems only relevant when implementing protocols etc, which the high-level interface is not intended for. So in that case, users will be using the hazardous interface anyway. 