### PR TITLE
Typed de-/serialization for JSON-based tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ alloc = []
 [dev-dependencies]
 hex = "0.4.0"
 serde_json = "1.0.41"
+serde = { version = "1.0", features = ["derive"] }
 quickcheck = "0.9.0"
 criterion = "0.3.0"
 

--- a/tests/aead/boringssl_tests.rs
+++ b/tests/aead/boringssl_tests.rs
@@ -1,14 +1,12 @@
-extern crate orion;
-
-use self::orion::hazardous::{
+use crate::aead::wycheproof_test_runner;
+use crate::TestCaseReader;
+use orion::hazardous::{
     mac::poly1305::POLY1305_OUTSIZE,
     stream::{
         chacha20::{CHACHA_KEYSIZE, IETF_CHACHA_NONCESIZE},
         xchacha20::XCHACHA_NONCESIZE,
     },
 };
-use crate::aead::wycheproof_test_runner;
-use crate::TestCaseReader;
 
 /// BoringSSLs ChaCha20Poly1305 and XChaCha20Poly1305 share the same format
 /// so the fields and separator remain the same.

--- a/tests/aead/mod.rs
+++ b/tests/aead/mod.rs
@@ -4,13 +4,10 @@ pub mod pynacl_streaming_aead;
 pub mod rfc_chacha20_poly1305;
 pub mod wycheproof_aead;
 
-extern crate orion;
-use self::{
-    aead::{
-        chacha20poly1305::{self, SecretKey},
-        xchacha20poly1305,
-    },
-    orion::{errors::UnknownCryptoError, hazardous::aead},
+use orion::errors::UnknownCryptoError;
+use orion::hazardous::aead::{
+    chacha20poly1305::{self, SecretKey},
+    xchacha20poly1305,
 };
 
 fn wycheproof_test_runner(

--- a/tests/aead/other_xchacha20_poly1305.rs
+++ b/tests/aead/other_xchacha20_poly1305.rs
@@ -3,8 +3,7 @@
 #[cfg(test)]
 mod sodiumoxide_xchacha20_poly1305 {
 
-    extern crate orion;
-    use self::orion::hazardous::aead;
+    use orion::hazardous::aead;
 
     #[test]
     fn test_case_0() {
@@ -86,10 +85,8 @@ mod sodiumoxide_xchacha20_poly1305 {
 #[cfg(test)]
 mod wireguard_xchacha20_poly1305 {
 
-    extern crate hex;
-    extern crate orion;
-
-    use self::{hex::decode, orion::hazardous::aead};
+    use hex::decode;
+    use orion::hazardous::aead;
 
     fn wireguard_test_runner(key: &[u8], nonce: &[u8], plaintext: &[u8], expected_ct: &[u8]) {
         // These test vector ciphertexts already include the tag

--- a/tests/aead/pynacl_streaming_aead.rs
+++ b/tests/aead/pynacl_streaming_aead.rs
@@ -1,65 +1,65 @@
 // Testing against PyNaCl test vectors
 // Latest commit when these test vectors were pulled: https://github.com/pyca/pynacl/commit/3bb12aef959c92f9042c150deec42cf104c40dfa
 // The generated test vectors have been generated the 26th October 2019.
-extern crate hex;
-extern crate orion;
-extern crate serde_json;
 
-use self::hex::decode;
-use core::convert::TryFrom;
-
-use self::serde_json::{Deserializer, Value};
+use hex::decode;
+use orion::hazardous::aead::streaming::*;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::{fs::File, io::BufReader};
 
-use orion::hazardous::aead::streaming::*;
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct TestCase {
+    key: String,
+    header: String,
+    chunks: Vec<TestCaseStreamingMessage>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct TestCaseStreamingMessage {
+    tag: u8,
+    ad: String,
+    message: String,
+    ciphertext: String,
+}
 
 fn run_tests_from_json(path_to_vectors: &str) {
     let file = File::open(path_to_vectors).unwrap();
     let reader = BufReader::new(file);
-    let stream = Deserializer::from_reader(reader).into_iter::<Value>();
+    let tests: Vec<TestCase> = serde_json::from_reader(reader).unwrap();
 
-    for test_file in stream {
-        for test_groups in test_file.unwrap().as_array() {
-            for test_case in test_groups {
-                let key = decode(test_case.get("key").unwrap().as_str().unwrap()).unwrap();
-                let nonce = decode(test_case.get("header").unwrap().as_str().unwrap()).unwrap();
+    for test in tests.iter() {
+        let key = SecretKey::from_slice(&decode(&test.key).unwrap()).unwrap();
+        let nonce = &Nonce::from_slice(&decode(&test.header).unwrap()).unwrap();
 
-                let mut ctx_seal = StreamXChaCha20Poly1305::new(
-                    &SecretKey::from_slice(&key).unwrap(),
-                    &Nonce::from_slice(&nonce).unwrap(),
-                );
+        let mut ctx_seal = StreamXChaCha20Poly1305::new(&key, &nonce);
+        let mut ctx_open = StreamXChaCha20Poly1305::new(&key, &nonce);
 
-                let mut ctx_open = StreamXChaCha20Poly1305::new(
-                    &SecretKey::from_slice(&key).unwrap(),
-                    &Nonce::from_slice(&nonce).unwrap(),
-                );
+        for chunk in test.chunks.iter() {
+            let chunk_msg = decode(&chunk.message).unwrap();
+            let chunk_ct = decode(&chunk.ciphertext).unwrap();
+            let chunk_ad = decode(&chunk.ad).unwrap();
 
-                for stream_chunks in test_case.get("chunks").unwrap().as_array() {
-                    for chunk in stream_chunks {
-                        let chunk_ad = decode(chunk.get("ad").unwrap().as_str().unwrap()).unwrap();
-                        let chunk_tag =
-                            StreamTag::try_from(chunk.get("tag").unwrap().as_u64().unwrap() as u8)
-                                .unwrap();
-                        let chunk_msg =
-                            decode(chunk.get("message").unwrap().as_str().unwrap()).unwrap();
-                        let chunk_ct =
-                            decode(chunk.get("ciphertext").unwrap().as_str().unwrap()).unwrap();
+            let mut chunk_out_ct = vec![0u8; chunk_ct.len()];
+            let mut chunk_out_pt = vec![0u8; chunk_msg.len()];
 
-                        let mut chunk_out_ct = vec![0u8; chunk_ct.len()];
-                        let mut chunk_out_pt = vec![0u8; chunk_msg.len()];
+            ctx_seal
+                .seal_chunk(
+                    &chunk_msg,
+                    Some(&chunk_ad),
+                    &mut chunk_out_ct,
+                    StreamTag::try_from(chunk.tag).unwrap(),
+                )
+                .unwrap();
 
-                        ctx_seal
-                            .seal_chunk(&chunk_msg, Some(&chunk_ad), &mut chunk_out_ct, chunk_tag)
-                            .unwrap();
-                        ctx_open
-                            .open_chunk(&chunk_ct, Some(&chunk_ad), &mut chunk_out_pt)
-                            .unwrap();
+            ctx_open
+                .open_chunk(&chunk_ct, Some(&chunk_ad), &mut chunk_out_pt)
+                .unwrap();
 
-                        assert_eq!(chunk_out_pt, chunk_msg);
-                        assert_eq!(chunk_out_ct, chunk_ct);
-                    }
-                }
-            }
+            assert_eq!(chunk_out_pt, chunk_msg);
+            assert_eq!(chunk_out_ct, chunk_ct);
         }
     }
 }

--- a/tests/aead/rfc_chacha20_poly1305.rs
+++ b/tests/aead/rfc_chacha20_poly1305.rs
@@ -2,9 +2,8 @@
 #[cfg(test)]
 mod rfc_aead_chacha20_poly1305 {
 
-    extern crate orion;
-    use self::orion::hazardous::aead;
     use crate::aead::wycheproof_test_runner;
+    use orion::hazardous::aead;
 
     #[test]
     fn test_case_0() {

--- a/tests/hash/blake2b_kat.rs
+++ b/tests/hash/blake2b_kat.rs
@@ -1,10 +1,5 @@
-extern crate hex;
-extern crate serde_json;
-
-use self::hex::decode;
-use super::*;
-
-use self::serde_json::{Deserializer, Value};
+use hex::decode;
+use serde_json::{Deserializer, Value};
 use std::{fs::File, io::BufReader};
 
 #[test]
@@ -18,7 +13,7 @@ fn test_blake2b_kat() {
             for test_case in test_object {
                 // Only test BLAKE2b test vectors
                 if test_case.get("hash").unwrap() == "blake2b" {
-                    blake2b_test_runner(
+                    super::blake2b_test_runner(
                         &decode(test_case.get("in").unwrap().as_str().unwrap()).unwrap(),
                         &decode(test_case.get("key").unwrap().as_str().unwrap()).unwrap(),
                         &decode(test_case.get("out").unwrap().as_str().unwrap()).unwrap(),

--- a/tests/hash/mod.rs
+++ b/tests/hash/mod.rs
@@ -2,8 +2,7 @@ pub mod blake2b_kat;
 pub mod other_blake2b;
 pub mod sha512_nist_cavp;
 
-extern crate orion;
-use self::orion::hazardous::hash::{blake2b, sha512};
+use orion::hazardous::hash::{blake2b, sha512};
 
 fn blake2b_test_runner(input: &[u8], key: &[u8], output: &[u8]) {
     // Only make SecretKey if test case key value is not empty.

--- a/tests/hash/other_blake2b.rs
+++ b/tests/hash/other_blake2b.rs
@@ -2,15 +2,11 @@
 // https://github.com/openssl/openssl/blob/2d0b44126763f989a4cbffbffe9d0c7518158bb7/test/evptests.txt
 // Taken at commit: 9257959
 
-use super::*;
-
 #[cfg(test)]
 mod openssl_test_vectors {
 
-    extern crate hex;
-
-    use self::hex::decode;
-    use super::*;
+    use super::super::blake2b_test_runner;
+    use hex::decode;
 
     #[test]
     fn openssl_test_case_0() {

--- a/tests/kdf/custom_hkdf.rs
+++ b/tests/kdf/custom_hkdf.rs
@@ -5,10 +5,8 @@
 #[cfg(test)]
 mod custom_hkdf {
 
-    extern crate hex;
-    use self::hex::decode;
-
     use crate::kdf::hkdf_test_runner;
+    use hex::decode;
 
     #[test]
     fn test_case_1() {

--- a/tests/kdf/custom_pbkdf2.rs
+++ b/tests/kdf/custom_pbkdf2.rs
@@ -5,10 +5,8 @@
 #[cfg(test)]
 mod custom_test_vectors {
 
-    extern crate hex;
-    extern crate orion;
-
-    use self::{hex::decode, orion::hazardous::kdf::pbkdf2::*};
+    use hex::decode;
+    use orion::hazardous::kdf::pbkdf2::{verify, Password};
 
     #[test]
     fn sha512_test_case_1() {

--- a/tests/kdf/mod.rs
+++ b/tests/kdf/mod.rs
@@ -9,8 +9,7 @@ pub mod pynacl_argon2i;
 pub mod ref_argon2i;
 pub mod wycheproof_hkdf;
 
-extern crate orion;
-use self::orion::hazardous::{kdf::hkdf::*, mac::hmac};
+use orion::hazardous::{kdf::hkdf::*, mac::hmac};
 
 pub fn hkdf_test_runner(
     expected_prk: Option<&[u8]>,

--- a/tests/kdf/other_argon2i.rs
+++ b/tests/kdf/other_argon2i.rs
@@ -3,10 +3,8 @@
 #[cfg(test)]
 mod other_argon2i {
 
-    extern crate hex;
-    extern crate orion;
-
-    use self::{hex::decode, orion::hazardous::kdf::argon2i};
+    use hex::decode;
+    use orion::hazardous::kdf::argon2i;
 
     #[test]
     fn test_case_0() {

--- a/tests/kdf/other_hkdf.rs
+++ b/tests/kdf/other_hkdf.rs
@@ -2,12 +2,8 @@
 #[cfg(test)]
 mod other_hkdf {
 
-    extern crate hex;
-    extern crate orion;
-
-    use self::hex::decode;
-
     use crate::kdf::hkdf_test_runner;
+    use hex::decode;
 
     #[test]
     fn test_case_1() {

--- a/tests/kdf/ref_argon2i.rs
+++ b/tests/kdf/ref_argon2i.rs
@@ -4,10 +4,7 @@
 #[cfg(test)]
 mod ref_argon2i {
 
-    extern crate hex;
-    extern crate orion;
-
-    use self::orion::hazardous::kdf::argon2i;
+    use orion::hazardous::kdf::argon2i;
 
     #[test]
     fn test_case_1() {

--- a/tests/kdf/wycheproof_hkdf.rs
+++ b/tests/kdf/wycheproof_hkdf.rs
@@ -1,58 +1,68 @@
 // Testing against Google Wycheproof test vectors
 // Latest commit when these test vectors were pulled: https://github.com/google/wycheproof/commit/2196000605e45d91097147c9c71f26b72af58003
-extern crate hex;
-extern crate serde_json;
 
-use self::hex::decode;
-
-use self::serde_json::{Deserializer, Value};
-use crate::kdf::hkdf_test_runner;
+use hex::decode;
+use serde::{Deserialize, Serialize};
 use std::{fs::File, io::BufReader};
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct WycheproofHkdfTests {
+    algorithm: String,
+    numberOfTests: u64,
+    testGroups: Vec<HkdfTestGroup>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct HkdfTestGroup {
+    keySize: u64,
+    tests: Vec<TestVector>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct TestVector {
+    tcId: u64,
+    comment: String,
+    ikm: String,
+    salt: String,
+    info: String,
+    size: usize,
+    okm: String,
+    result: String,
+    flags: Vec<String>,
+}
 
 fn wycheproof_runner(path: &str) {
     let file = File::open(path).unwrap();
     let reader = BufReader::new(file);
-    let stream = Deserializer::from_reader(reader).into_iter::<Value>();
+    let tests: WycheproofHkdfTests = serde_json::from_reader(reader).unwrap();
 
-    for test_file in stream {
-        for test_groups in test_file.unwrap().get("testGroups") {
-            for test_group_collection in test_groups.as_array() {
-                for test_group in test_group_collection {
-                    for test_vectors in test_group.get("tests").unwrap().as_array() {
-                        for test_case in test_vectors {
-                            let ikm =
-                                decode(test_case.get("ikm").unwrap().as_str().unwrap()).unwrap();
-                            let salt =
-                                decode(test_case.get("salt").unwrap().as_str().unwrap()).unwrap();
-                            let info =
-                                decode(test_case.get("info").unwrap().as_str().unwrap()).unwrap();
-                            let okm_len = test_case.get("size").unwrap().as_u64().unwrap();
-                            let okm =
-                                decode(test_case.get("okm").unwrap().as_str().unwrap()).unwrap();
-                            let result: bool =
-                                match test_case.get("result").unwrap().as_str().unwrap() {
-                                    "valid" => true,
-                                    "invalid" => false,
-                                    _ => panic!("Unrecognized result detected!"),
-                                };
-                            let tcid = test_case.get("tcId").unwrap().as_u64().unwrap();
-                            println!("tcId: {}, okm_len: {}", tcid, okm_len);
+    let mut tests_run = 0;
+    for test_group in tests.testGroups.iter() {
+        for test in test_group.tests.iter() {
+            let should_test_pass: bool = match test.result.as_str() {
+                "valid" => true,
+                "invalid" => false,
+                _ => panic!("Unexpected test outcome for Wycheproof test"),
+            };
 
-                            hkdf_test_runner(
-                                None,
-                                &okm,
-                                &salt,
-                                &ikm,
-                                &info,
-                                okm_len as usize,
-                                result,
-                            );
-                        }
-                    }
-                }
-            }
+            super::hkdf_test_runner(
+                None,
+                &decode(&test.okm).unwrap(),
+                &decode(&test.salt).unwrap(),
+                &decode(&test.ikm).unwrap(),
+                &decode(&test.info).unwrap(),
+                test.size,
+                should_test_pass,
+            );
+
+            tests_run += 1;
         }
     }
+
+    assert_eq!(tests_run, tests.numberOfTests);
 }
 
 #[test]

--- a/tests/mac/mod.rs
+++ b/tests/mac/mod.rs
@@ -5,13 +5,9 @@ pub mod rfc_hmac;
 pub mod rfc_poly1305;
 pub mod wycheproof_hmac_sha512;
 
-extern crate orion;
-
-use self::{
-    orion::hazardous::hash::sha512::SHA512_OUTSIZE,
-    orion::hazardous::mac::{hmac, poly1305},
-    poly1305::{OneTimeKey, Tag},
-};
+use orion::hazardous::hash::sha512::SHA512_OUTSIZE;
+use orion::hazardous::mac::{hmac, poly1305};
+use poly1305::{OneTimeKey, Tag};
 
 fn hmac_test_runner(
     expected: &[u8],

--- a/tests/mac/other_poly1305.rs
+++ b/tests/mac/other_poly1305.rs
@@ -1,10 +1,8 @@
 #[cfg(test)]
 mod other_poly1305 {
 
-    extern crate hex;
-
-    use self::hex::decode;
     use crate::mac::poly1305_test_runner;
+    use hex::decode;
 
     // Generated with libsodium 1.0.18
     #[test]

--- a/tests/mac/rfc_hmac.rs
+++ b/tests/mac/rfc_hmac.rs
@@ -2,10 +2,8 @@
 #[cfg(test)]
 mod rfc4231 {
 
-    extern crate hex;
-
-    use self::hex::decode;
     use crate::mac::hmac_test_runner;
+    use hex::decode;
 
     #[test]
     fn test_case_1() {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -12,8 +12,7 @@ pub mod mac;
 #[cfg(test)]
 pub mod stream;
 
-extern crate hex;
-use self::hex::decode;
+use hex::decode;
 
 use std::{
     collections::HashMap,

--- a/tests/stream/mod.rs
+++ b/tests/stream/mod.rs
@@ -2,16 +2,10 @@ pub mod other_chacha20;
 pub mod rfc_chacha20;
 pub mod rfc_xchacha20;
 
-extern crate orion;
-
-use self::{
-    chacha20::SecretKey,
-    orion::hazardous::stream::{
-        chacha20::{self, IETF_CHACHA_NONCESIZE},
-        xchacha20::{self, XCHACHA_NONCESIZE},
-    },
-};
+use chacha20::SecretKey;
 use orion::hazardous::stream::chacha20::CHACHA_KEYSIZE;
+use orion::hazardous::stream::chacha20::{self, IETF_CHACHA_NONCESIZE};
+use orion::hazardous::stream::xchacha20::{self, XCHACHA_NONCESIZE};
 use orion::test_framework::streamcipher_interface::StreamCipherTestRunner;
 
 pub fn chacha_test_runner(

--- a/tests/stream/rfc_chacha20.rs
+++ b/tests/stream/rfc_chacha20.rs
@@ -2,10 +2,8 @@
 #[cfg(test)]
 mod rfc8439_chacha20 {
 
-    extern crate hex;
-
-    use self::hex::decode;
     use crate::stream::chacha_test_runner;
+    use hex::decode;
 
     #[test]
     fn chacha20_encryption_test_0() {

--- a/tests/stream/rfc_xchacha20.rs
+++ b/tests/stream/rfc_xchacha20.rs
@@ -1,10 +1,7 @@
 #[cfg(test)]
 mod draft_rfc_xchacha20 {
-
-    extern crate hex;
-
-    use self::hex::decode;
     use crate::stream::chacha_test_runner;
+    use hex::decode;
 
     #[test]
     fn xchacha20_encryption_test_0() {


### PR DESCRIPTION
This is an additional to #129.

Using type-based de-/serialization significantly cleans the code and rids us of unearthly amounts of `unwrap()`s. 
