### PR TITLE
Update license year and correct files that had a date too early

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 The orion Developers
+Copyright (c) 2018-2021 The orion Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/aead/mod.rs
+++ b/src/hazardous/aead/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/hash/blake2b.rs
+++ b/src/hazardous/hash/blake2b.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/hash/mod.rs
+++ b/src/hazardous/hash/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/hash/sha512.rs
+++ b/src/hazardous/hash/sha512.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/kdf/argon2i.rs
+++ b/src/hazardous/kdf/argon2i.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2020 The orion Developers
+// Copyright (c) 2020-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/kdf/hkdf.rs
+++ b/src/hazardous/kdf/hkdf.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/kdf/mod.rs
+++ b/src/hazardous/kdf/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/kdf/pbkdf2.rs
+++ b/src/hazardous/kdf/pbkdf2.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/mac/mod.rs
+++ b/src/hazardous/mac/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 // Based on the algorithm from https://github.com/floodyberry/poly1305-donna
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/hazardous/mod.rs
+++ b/src/hazardous/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/stream/mod.rs
+++ b/src/hazardous/stream/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/high_level/aead.rs
+++ b/src/high_level/aead.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2020-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/high_level/auth.rs
+++ b/src/high_level/auth.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2020-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/high_level/hash.rs
+++ b/src/high_level/hash.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2020-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/high_level/hltypes.rs
+++ b/src/high_level/hltypes.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2020-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/high_level/kdf.rs
+++ b/src/high_level/kdf.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2020-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/high_level/mod.rs
+++ b/src/high_level/mod.rs
@@ -1,3 +1,14 @@
+// MIT License
+
+// Copyright (c) 2020-2021 The orion Developers
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
 

--- a/src/high_level/pwhash.rs
+++ b/src/high_level/pwhash.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2020-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/test_framework/aead_interface.rs
+++ b/src/test_framework/aead_interface.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/test_framework/incremental_interface.rs
+++ b/src/test_framework/incremental_interface.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/test_framework/mod.rs
+++ b/src/test_framework/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/util/endianness.rs
+++ b/src/util/endianness.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2018-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/util/u32x4.rs
+++ b/src/util/u32x4.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/util/u64x4.rs
+++ b/src/util/u64x4.rs
@@ -1,6 +1,6 @@
 // MIT License
 
-// Copyright (c) 2018-2020 The orion Developers
+// Copyright (c) 2019-2021 The orion Developers
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes #141 and updates the license year to 2021.

File's start-date was determined by their first existence in the git log. Using this script:

```bash
for f in $(find ./ -type f);
do
echo $f;
git log --format=%aD $f | tail -1;
done
```

The same needs to be checked for newer files in `v016`.