### PR TITLE
Doc: Change the example in orion::auth

### DIFF
--- a/src/high_level/auth.rs
+++ b/src/high_level/auth.rs
@@ -57,14 +57,14 @@
 //! ```rust
 //! use orion::auth;
 //!
-//! // There exists a shared key between the user and API endpoint
+//! // There exists a shared key between the user and API server
 //! let key = auth::SecretKey::default();
 //!
 //! // User generates message and authentication tag
 //! let msg = "Some message.".as_bytes();
 //! let expected_tag = auth::authenticate(&key, msg)?;
 //!
-//! // API endpoint verifies the authenticity of the message with the tag
+//! // API server verifies the authenticity of the message with the tag
 //! assert!(auth::authenticate_verify(&expected_tag, &key, &msg).is_ok());
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```

--- a/src/high_level/auth.rs
+++ b/src/high_level/auth.rs
@@ -56,14 +56,14 @@
 //! # Example:
 //! ```rust
 //! use orion::auth;
-//! 
+//!
 //! // There exists a shared key between the user and API endpoint
 //! let key = auth::SecretKey::default();
-//! 
+//!
 //! // User generates message and authentication tag
 //! let msg = "Some message.".as_bytes();
 //! let expected_tag = auth::authenticate(&key, msg)?;
-//! 
+//!
 //! // API endpoint verifies the authenticity of the message with the tag
 //! assert!(auth::authenticate_verify(&expected_tag, &key, &msg).is_ok());
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())

--- a/src/high_level/auth.rs
+++ b/src/high_level/auth.rs
@@ -56,11 +56,15 @@
 //! # Example:
 //! ```rust
 //! use orion::auth;
-//!
+//! 
+//! // There exists a shared key between the user and API endpoint
 //! let key = auth::SecretKey::default();
+//! 
+//! // User generates message and authentication tag
 //! let msg = "Some message.".as_bytes();
-//!
 //! let expected_tag = auth::authenticate(&key, msg)?;
+//! 
+//! // API endpoint verifies the authenticity of the message with the tag
 //! assert!(auth::authenticate_verify(&expected_tag, &key, &msg).is_ok());
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```


### PR DESCRIPTION
Closes #159 

@vlmutolo Does this change make sense, is it clear? I've extended upon your suggestion a bit, in order to make the comments align more the the use-case description/example in the top of the module docs.

> `orion::auth` can be used to ensure message integrity and authenticity by
using a secret key.
>
> An example of this could be securing APIs by having a user of a given API
sign their API request and having the API server verify these signed API
requests. 