### PR TITLE
Limit high-level, variable-length newtype's input to isize::MAX

### DIFF
--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -160,7 +160,8 @@ macro_rules! func_from_slice_variable_size (($name:ident) => (
     #[cfg(feature = "safe_api")]
     /// Construct from a given byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<$name, UnknownCryptoError> {
-        if slice.is_empty() {
+        // See issue on `isize` limit: https://github.com/brycx/orion/issues/130
+        if slice.is_empty() || slice.len() > (isize::MAX as usize) {
             return Err(UnknownCryptoError);
         }
 
@@ -214,7 +215,8 @@ macro_rules! func_generate_variable_size (($name:ident) => (
     #[cfg(feature = "safe_api")]
     /// Randomly generate using a CSPRNG. Not available in `no_std` context.
     pub fn generate(length: usize) -> Result<$name, UnknownCryptoError> {
-        if length < 1 || length >= (u32::MAX as usize) {
+        // See issue on `isize` limit: https://github.com/brycx/orion/issues/130
+        if length < 1 || length > (isize::MAX as usize) {
             return Err(UnknownCryptoError);
         }
 

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -363,7 +363,7 @@ macro_rules! test_generate_variable (($name:ident) => (
     #[cfg(feature = "safe_api")]
     fn test_generate_variable() {
         assert!($name::generate(0).is_err());
-        assert!($name::generate((isize::MAX + 1) as usize).is_err());
+        assert!($name::generate((isize::MAX as usize) + 1).is_err());
         assert!($name::generate(1).is_ok());
         assert!($name::generate(64).is_ok());
 

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -363,7 +363,7 @@ macro_rules! test_generate_variable (($name:ident) => (
     #[cfg(feature = "safe_api")]
     fn test_generate_variable() {
         assert!($name::generate(0).is_err());
-        assert!($name::generate(usize::MAX).is_err());
+        assert!($name::generate((isize::MAX + 1) as usize).is_err());
         assert!($name::generate(1).is_ok());
         assert!($name::generate(64).is_ok());
 


### PR DESCRIPTION
Closes #130 