### PR TITLE
Use constant-time Base64 in `pwhash::PasswordHash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ exclude = [
 subtle = { version = "^2.2.2", default-features = false }
 zeroize = { version = "1.1.0", default-features = false }
 getrandom = { version = "0.2.0", optional = true }
-base64 = { version = "0.13.0", optional = true }
+ct-codecs = { version = "1.1.1", optional = true }
 
 [features]
 default = [ "safe_api" ]
-safe_api = [ "getrandom", "base64" ]
+safe_api = [ "getrandom", "ct-codecs" ]
 alloc = []
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,8 +53,8 @@ impl From<getrandom::Error> for UnknownCryptoError {
 }
 
 #[cfg(feature = "safe_api")]
-impl From<base64::DecodeError> for UnknownCryptoError {
-    fn from(_: base64::DecodeError) -> Self {
+impl From<ct_codecs::Error> for UnknownCryptoError {
+    fn from(_: ct_codecs::Error) -> Self {
         UnknownCryptoError
     }
 }
@@ -104,11 +104,10 @@ fn test_source() {
 #[test]
 #[cfg(feature = "safe_api")]
 fn test_unknown_crypto_from_decode_error() {
-    use base64::DecodeError;
+    use ct_codecs::Error;
 
-    let err_one = DecodeError::InvalidByte(0, 0);
-    let err_two = DecodeError::InvalidLastSymbol(0, 0);
-    let err_three = DecodeError::InvalidLength;
+    let err_one = Error::InvalidInput;
+    let err_two = Error::Overflow;
 
     // Tests Debug impl through "{:?}" and Display impl though "{}"
     let err = format!(
@@ -121,12 +120,6 @@ fn test_unknown_crypto_from_decode_error() {
         "{:?}{}",
         UnknownCryptoError::from(err_two.clone()),
         UnknownCryptoError::from(err_two)
-    );
-    assert_eq!(err, "UnknownCryptoErrorUnknownCryptoError");
-    let err = format!(
-        "{:?}{}",
-        UnknownCryptoError::from(err_three.clone()),
-        UnknownCryptoError::from(err_three)
     );
     assert_eq!(err, "UnknownCryptoErrorUnknownCryptoError");
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -111,17 +111,17 @@ fn test_unknown_crypto_from_decode_error() {
 
     // Tests Debug impl through "{:?}" and Display impl though "{}"
     let err = format!(
-        "{:?}{}",
+        "{:?}:{}",
         UnknownCryptoError::from(err_one.clone()),
         UnknownCryptoError::from(err_one)
     );
-    assert_eq!(err, "UnknownCryptoErrorUnknownCryptoError");
+    assert_eq!(err, "UnknownCryptoError:UnknownCryptoError");
     let err = format!(
-        "{:?}{}",
+        "{:?}:{}",
         UnknownCryptoError::from(err_two.clone()),
         UnknownCryptoError::from(err_two)
     );
-    assert_eq!(err, "UnknownCryptoErrorUnknownCryptoError");
+    assert_eq!(err, "UnknownCryptoError:UnknownCryptoError");
 }
 
 #[test]
@@ -131,9 +131,9 @@ fn test_unknown_crypto_from_parseint_error() {
 
     // Tests Debug impl through "{:?}" and Display impl though "{}"
     let err = format!(
-        "{:?}{}",
+        "{:?}:{}",
         UnknownCryptoError::from(err_foreign.clone()),
         UnknownCryptoError::from(err_foreign)
     );
-    assert_eq!(err, "UnknownCryptoErrorUnknownCryptoError");
+    assert_eq!(err, "UnknownCryptoError:UnknownCryptoError");
 }


### PR DESCRIPTION
Replace the current Base64 dependency with one that provides constant-time encoding & decoding.


closes #188 