### PR TITLE
add initial serde support for relevant types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ subtle = { version = "^2.2.2", default-features = false }
 zeroize = { version = "1.1.0", default-features = false }
 getrandom = { version = "0.2.0", optional = true }
 ct-codecs = { version = "1.1.1", optional = true }
+serde = { version = "1.0.124", optional = true }
 
 [features]
 default = [ "safe_api" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,9 @@ extern crate quickcheck_macros;
 #[cfg_attr(feature = "alloc", macro_use)]
 extern crate alloc;
 
+#[cfg(feature = "serde")]
+mod serde_impls;
+
 #[macro_use]
 mod typedefs;
 

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,0 +1,85 @@
+use crate::{auth, hash, kdf, pwhash::PasswordHash};
+use serde::{
+    de::{self, Deserialize, Deserializer},
+    ser::{Serialize, Serializer},
+};
+
+impl Serialize for PasswordHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let encoded_string = self.unprotected_as_encoded();
+        serializer.serialize_str(&encoded_string)
+    }
+}
+
+impl<'de> Deserialize<'de> for PasswordHash {
+    fn deserialize<D>(deserializer: D) -> Result<PasswordHash, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded_str = <&str>::deserialize(deserializer)?;
+        PasswordHash::from_encoded(encoded_str).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for hash::Digest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes: &[u8] = self.as_ref();
+        bytes.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for hash::Digest {
+    fn deserialize<D>(deserializer: D) -> Result<hash::Digest, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <&[u8]>::deserialize(deserializer)?;
+        hash::Digest::from_slice(bytes).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for auth::Tag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes: &[u8] = self.unprotected_as_bytes();
+        bytes.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for auth::Tag {
+    fn deserialize<D>(deserializer: D) -> Result<auth::Tag, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <&[u8]>::deserialize(deserializer)?;
+        auth::Tag::from_slice(bytes).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for kdf::Salt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes: &[u8] = self.as_ref();
+        bytes.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for kdf::Salt {
+    fn deserialize<D>(deserializer: D) -> Result<kdf::Salt, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <&[u8]>::deserialize(deserializer)?;
+        kdf::Salt::from_slice(bytes).map_err(de::Error::custom)
+    }
+}


### PR DESCRIPTION
Resolves #192.

This is still a draft PR. The following items should be addressed before merging.

[ ] No tests are currently implemented. I still have to think about what the best test cases would be. Suggestions are welcome.
[ ] When it was available for the given type, serialization implementations use `unprotected_as_bytes` over the `AsRef<[u8]>` trait impl. Should we prefer using `AsRef` for consistency with types that don't have `unproected_as_bytes`, or is there some reason to prefer `unprotected_as_bytes` for its semantics? I'm leaning toward just using `AsRef` for everything that converts to/from byte slices.
[ ] All the serde-related logic is implemented here in a separate module. I've taken to doing it this way in my own projects to keep the boilerplate out of the modules for each type, but I'm happy to break it up and move the four serde implementations nearer to where the types themselves are defined.
[ ] Another style point: I prefixed most of the types with their module names instead of importing them directly. For example, `kdf::Salt` instead of just `Salt`. I was concerned that other types may implement `Salt` in the future and we may add them to the `serde` module. This is a downside of keeping everything in one module; the names may have to be differentiated further.